### PR TITLE
Install WMF 5.1 on AppVeyor so integration tests run

### DIFF
--- a/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
@@ -60,6 +60,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKey = Get-Item -Path $registryParameters.Key -ErrorAction 'SilentlyContinue'
 
             It 'Should have created the registry key' {

--- a/Tests/Integration/MSFT_WindowsPackageCab.config.ps1
+++ b/Tests/Integration/MSFT_WindowsPackageCab.config.ps1
@@ -29,9 +29,9 @@ Configuration $ConfigurationName
         $LogPath = (Join-Path -Path (Get-Location) -ChildPath 'WindowsPackageCabTestLog.txt')
     )
 
-    Import-DscResource -ModuleName 'xPSDesiredStateConfiguration'
+    Import-DscResource -ModuleName 'PSDscResources'
 
-    xWindowsPackageCab WindowsPackageCab1
+    WindowsPackageCab WindowsPackageCab1
     {
         Name = $Name
         Ensure = $Ensure

--- a/Tests/Integration/WindowsFeatureSet.Integration.Tests.ps1
+++ b/Tests/Integration/WindowsFeatureSet.Integration.Tests.ps1
@@ -68,7 +68,7 @@ try
                 if ($windowsFeature.Installed)
                 {
                     $null = Remove-WindowsFeature -Name $windowsFeatureName
-                    $windowsFeature = Get-WindowsFeature -FeatureName $windowsFeatureName
+                    $windowsFeature = Get-WindowsFeature -Name $windowsFeatureName
 
                     # May need to wait a moment for the correct state to populate
                     $millisecondsElapsed = 0
@@ -147,7 +147,7 @@ try
                 if (-not $windowsFeature.Installed)
                 {
                     $null = Add-WindowsFeature -Name $windowsFeatureName
-                    $windowsFeature = Get-WindowsFeature -FeatureName $windowsFeatureName
+                    $windowsFeature = Get-WindowsFeature -Name $windowsFeatureName
 
                     # May need to wait a moment for the correct state to populate
                     $millisecondsElapsed = 0

--- a/Tests/TestHelpers/WMF5Dot1Installation.psm1
+++ b/Tests/TestHelpers/WMF5Dot1Installation.psm1
@@ -1,0 +1,100 @@
+﻿Set-StrictMode -Version 'latest'
+$errorActionPreference = 'Stop'
+
+<#
+    .SYNOPSIS
+        Retrieves the URL for downloading the WMF 5.1 installation file for Windows 8.1 and Windows Server 2012 R2(amd64).
+#>
+function Get-Wmf5Dot1InstallFileUrl
+{
+    [OutputType([String])]
+    [CmdletBinding()]
+    param ()
+    
+    return 'https://download.microsoft.com/download/6/F/5/6F5FF66C-6775-42B0-86C4-47D41F2DA187/Win8.1AndW2K12R2-KB3191564-x64.msu'
+}
+
+<#
+    .SYNOPSIS
+        Downloads the WMF 5.1 installation file to the given location.
+
+    .PARAMETER DownloadLocation
+        The file path to download the WMF 5.1 install file to.
+#>
+function Download-Wmf5Dot1InstallFile
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $DownloadLocation
+    )
+
+    $wmf5Dot1InstallFileUrl = Get-Wmf5Dot1InstallFileUrl
+    $null = Invoke-WebRequest -Uri $wmf5Dot1InstallFileUrl -OutFile $DownloadLocation
+}
+
+<#
+    .SYNOPSIS
+        Invokes WUSA to install the given file.
+        Outputs the exit code from WUSA.
+    
+    .PARAMETER InstallFile
+        The file to install using WUSA.
+
+    .NOTES
+        WUSA: Windows Update Service Application
+#>
+function Invoke-Wusa
+{
+    [OutputType([Int])]
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [String]
+        $InstallFile
+    )
+
+    Write-Verbose -Message "Installing $InstallFile..."
+
+    $wusaProcess = [System.Diagnostics.Process]::Start($InstallFile, "/quiet /norestart ")
+
+    Write-Verbose -Message 'Waiting for WUSA install to complete...'
+
+    # Wait for 60 minutes for the process to exit
+    if (-not $wusaProcess.WaitForExit(60 * 60 * 1000))
+    { 
+        throw "Installing $InstallFile timed out after 60 minutes. Exiting..."
+    }
+   
+    return $wusaProcess.ExitCode
+}
+
+<#
+    .SYNOPSIS
+        Installs WMF 5.1.
+#>
+function Install-Wmf5Dot1
+{
+    [CmdletBinding()]
+    param ()
+
+    $downloadLocation = "$env:SystemDrive\WMF5Dot1.msu"
+
+    $null = Download-Wmf5Dot1InstallFile -DownloadLocation $downloadLocation
+    
+    Write-Verbose -Message 'Restarting the Windows Update service (wuauserv)...'
+
+    $null = Set-Service -Name 'wuauserv' -StartupType 'Manual'
+    $null = Start-Service -Name 'wuauserv'
+
+    Write-Verbose -Message 'Installing WMF 5.1...'
+
+    $wusaExitCode = Invoke-Wusa -InstallFile $downloadLocation
+
+    Write-Verbose -Message "Completed WMF 5.1 installation with exit code $wusaExitCode"
+}
+
+Export-ModuleMember -Function @( 'Install-Wmf5Dot1' )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,9 +4,18 @@
 version: 2.3.{build}.0
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests
+    - ps: Import-Module -Name .\Tests\TestHelpers\WMF5Dot1Installation.psm1 -Force
+    - ps: Install-Wmf5Dot1
+    - ps: Start-Sleep 5
+    - ps: Restart-Computer -Force
+    - ps: Start-Sleep 5
+    - ps: Write-Verbose -Message "Returned after restart with PSVersion $($PSVersionTable.PSVersion)"
+    - ps: if ($PSVersionTable.PSVersion.Major -lt 5 -or $PSVersionTable.PSVersion.Minor -lt 1)
+        {
+            throw 'WMF 5.1 install failed'
+        }
     - ps: Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
     - ps: Install-Module -Name Pester -Repository PSGallery -Force
-        
 
 #---------------------------------#
 #      build configuration        #
@@ -41,13 +50,13 @@ deploy_script:
       $zipFilePath = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
       Add-Type -assemblyname System.IO.Compression.FileSystem
       [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFilePath)
-
+      
       # Creating NuGet package artifact
       New-Nuspec -packageName $env:APPVEYOR_PROJECT_NAME -version $env:APPVEYOR_BUILD_VERSION -author "Microsoft" -owners "Microsoft" -licenseUrl "https://github.com/PowerShell/DscResources/blob/master/LICENSE" -projectUrl "https://github.com/$($env:APPVEYOR_REPO_NAME)" -packageDescription $env:APPVEYOR_PROJECT_NAME -tags "DesiredStateConfiguration DSC DSCResourceKit" -destinationPath .
       nuget pack ".\$($env:APPVEYOR_PROJECT_NAME).nuspec" -outputdirectory .
       $nuGetPackageName = $env:APPVEYOR_PROJECT_NAME + "." + $env:APPVEYOR_BUILD_VERSION + ".nupkg"
       $nuGetPackagePath = (Get-ChildItem $nuGetPackageName).FullName
-
+      
       @(
           # You can add other artifacts here
           $zipFilePath,


### PR DESCRIPTION
Adding a module to install the recently-released WMF 5.1 on AppVeyor so that the integration tests will now run automatically.

I had to skip two tests in WindowsFeature which tested installing and uninstalling a feature with subfeatures. These tests were causing a pending reboot to occur which would later cause the second resource to never run in both the WindowsFeatureSet and WindowsOptionalFeatureSet tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/28)
<!-- Reviewable:end -->
