### PR TITLE
Add 'NT Authority' to local machine scopes

### DIFF
--- a/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
+++ b/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
@@ -546,20 +546,11 @@ function Set-TargetResourceOnFullSKU
 
         if ($Ensure -eq 'Present')
         {
-            $actualMembersAsPrincipals = $null
-
             $shouldProcessTarget = $script:localizedData.GroupWithName -f $GroupName
             if ($groupOriginallyExists)
             {
                 $null = $disposables.Add($group)
                 $whatIfShouldProcess = $PSCmdlet.ShouldProcess($shouldProcessTarget, $script:localizedData.SetOperation)
-
-                $actualMembersAsPrincipals = @( Get-MembersAsPrincipalsList `
-                    -Group $group `
-                    -PrincipalContextCache $principalContextCache `
-                    -Disposables $disposables `
-                    -Credential $Credential
-                )
             }
             else
             {
@@ -591,6 +582,8 @@ function Set-TargetResourceOnFullSKU
                     $saveChanges = $true
                 }
 
+                $actualMembersAsPrincipals = $null
+
                 <#
                     Group members can be updated in two ways:
                     1. Supplying the Members parameter - this causes the membership to be replaced
@@ -614,6 +607,16 @@ function Set-TargetResourceOnFullSKU
                             New-InvalidArgumentException -ArgumentName $incompatibleParameterName `
                                 -Message ($script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', $incompatibleParameterName)
                         }
+                    }
+
+                    if ($groupOriginallyExists)
+                    {
+                        $actualMembersAsPrincipals = @( Get-MembersAsPrincipalsList `
+                            -Group $group `
+                            -PrincipalContextCache $principalContextCache `
+                            -Disposables $disposables `
+                            -Credential $Credential
+                        )
                     }
 
                     if ($Members.Count -eq 0 -and $null -ne $actualMembersAsPrincipals -and $actualMembersAsPrincipals.Count -ne 0)
@@ -669,8 +672,18 @@ function Set-TargetResourceOnFullSKU
                         Write-Verbose -Message ($script:localizedData.GroupAndMembersEmpty -f $GroupName)
                     }
                 }
-                else
+                elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -or $PSBoundParameters.ContainsKey('MembersToExclude'))
                 {
+                    if ($groupOriginallyExists)
+                    {
+                        $actualMembersAsPrincipals = @( Get-MembersAsPrincipalsList `
+                            -Group $group `
+                            -PrincipalContextCache $principalContextCache `
+                            -Disposables $disposables `
+                            -Credential $Credential
+                        )
+                    }
+
                     $membersToIncludeAsPrincipals = $null
                     $uniqueMembersToInclude = $MembersToInclude | Select-Object -Unique
 
@@ -916,8 +929,6 @@ function Set-TargetResourceOnNanoServer
                 Set-LocalGroup -Name $GroupName -Description $Description
             }
 
-            $groupMembers = Get-MembersOnNanoServer -Group $group
-
             if ($PSBoundParameters.ContainsKey('Members'))
             {
                 foreach ($incompatibleParameterName in @( 'MembersToInclude', 'MembersToExclude' ))
@@ -928,6 +939,8 @@ function Set-TargetResourceOnNanoServer
                             -Message ($script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', $incompatibleParameterName)
                     }
                 }
+
+                $groupMembers = Get-MembersOnNanoServer -Group $group
 
                 # Remove duplicate names as strings.
                 $uniqueMembers = $Members | Select-Object -Unique
@@ -950,8 +963,10 @@ function Set-TargetResourceOnNanoServer
                     }
                 }
             }
-            else
+            elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -or $PSBoundParameters.ContainsKey('MembersToExclude'))
             {
+                $groupMembers = Get-MembersOnNanoServer -Group $group
+
                 $uniqueMembersToInclude = $MembersToInclude | Select-Object -Unique
                 $uniqueMembersToExclude = $MembersToExclude | Select-Object -Unique
 
@@ -1134,15 +1149,9 @@ function Test-TargetResourceOnFullSKU
             return $false
         }
 
-        $actualMembersAsPrincipals = @( Get-MembersAsPrincipalsList `
-            -Group $group `
-            -PrincipalContextCache $principalContextCache `
-            -Disposables $disposables `
-            -Credential $Credential
-        )
-
         if ($PSBoundParameters.ContainsKey('Members'))
         {
+            
             foreach ($incompatibleParameterName in @( 'MembersToInclude', 'MembersToExclude' ))
             {
                 if ($PSBoundParameters.ContainsKey($incompatibleParameterName))
@@ -1151,6 +1160,13 @@ function Test-TargetResourceOnFullSKU
                         -Message ($script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', $incompatibleParameterName)
                 }
             }
+
+            $actualMembersAsPrincipals = @( Get-MembersAsPrincipalsList `
+                -Group $group `
+                -PrincipalContextCache $principalContextCache `
+                -Disposables $disposables `
+                -Credential $Credential
+            )
 
             $uniqueMembers = $Members | Select-Object -Unique
 
@@ -1192,8 +1208,15 @@ function Test-TargetResourceOnFullSKU
                 }
             }
         }
-        else
+        elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -or $PSBoundParameters.ContainsKey('MembersToExclude'))
         {
+            $actualMembersAsPrincipals = @( Get-MembersAsPrincipalsList `
+                -Group $group `
+                -PrincipalContextCache $principalContextCache `
+                -Disposables $disposables `
+                -Credential $Credential
+            )
+
             $membersToIncludeAsPrincipals = $null
             $uniqueMembersToInclude = $MembersToInclude | Select-Object -Unique
 
@@ -1388,8 +1411,6 @@ function Test-TargetResourceOnNanoServer
         return $false
     }
 
-    $groupMembers = Get-MembersOnNanoServer -Group $group
-
     if ($PSBoundParameters.ContainsKey('Members'))
     {
         foreach ($incompatibleParameterName in @( 'MembersToInclude', 'MembersToExclude' ))
@@ -1400,6 +1421,8 @@ function Test-TargetResourceOnNanoServer
                     -Message ($script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', $incompatibleParameterName)
             }
         }
+
+        $groupMembers = Get-MembersOnNanoServer -Group $group
 
         # Remove duplicate names as strings.
         $uniqueMembers = $Members | Select-Object -Unique
@@ -1424,8 +1447,10 @@ function Test-TargetResourceOnNanoServer
             }
         }
     }
-    else
+    elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -or $PSBoundParameters.ContainsKey('MembersToExclude'))
     {
+        $groupMembers = Get-MembersOnNanoServer -Group $group
+
         $uniqueMembersToInclude = $MembersToInclude | Select-Object -Unique
         $uniqueMembersToExclude = $MembersToExclude | Select-Object -Unique
 

--- a/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
+++ b/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
@@ -1099,7 +1099,6 @@ function Test-TargetResourceOnFullSKU
         [String]
         $Description,
 
-        [ValidateNotNull()]
         [String[]]
         $Members,
 
@@ -1122,7 +1121,7 @@ function Test-TargetResourceOnFullSKU
     {
         $principalContext = Get-PrincipalContext `
             -PrincipalContextCache $PrincipalContextCache `
-            -Disposables $Disposables `
+            -Disposables $disposables `
             -Scope $env:computerName
 
         $group = Get-Group -GroupName $GroupName -PrincipalContext $principalContext
@@ -1151,7 +1150,6 @@ function Test-TargetResourceOnFullSKU
 
         if ($PSBoundParameters.ContainsKey('Members'))
         {
-            
             foreach ($incompatibleParameterName in @( 'MembersToInclude', 'MembersToExclude' ))
             {
                 if ($PSBoundParameters.ContainsKey($incompatibleParameterName))
@@ -1362,7 +1360,6 @@ function Test-TargetResourceOnNanoServer
         [String]
         $Description,
 
-        [ValidateNotNull()]
         [String[]]
         $Members,
 
@@ -2159,7 +2156,7 @@ function Test-IsLocalMachine
         $Scope
     )
 
-    $localMachineScopes = @( '.', $env:computerName, 'localhost', '127.0.0.1' )
+    $localMachineScopes = @( '.', $env:computerName, 'localhost', '127.0.0.1', 'NT Authority' )
 
     if ($localMachineScopes -icontains $Scope)
     {
@@ -2572,5 +2569,3 @@ function Remove-DisposableObject
         }
     }
 }
-
-Export-ModuleMember -Function '*-TargetResource'

--- a/README.md
+++ b/README.md
@@ -474,6 +474,12 @@ The following parameters will be the same for each process in the set:
 
 * Cleaned User
 * Updated User to have non-dependent unit tests.
+* Ported fixes from [xPSDesiredStateConfiguration](https://github.com/PowerShell/xPSDesiredStateConfiguration):
+    * WindowsProcess: Minor updates to integration tests
+    * Registry: Fixed support for forward slashes in registry key names
+* Group:
+    * Group members in the "NT Authority" scope should now be resolved without an error. If you were seeing the error "Exception calling ".ctor" with "4" argument(s): "Server names cannot contain a space character."", this fix should resolve that error.
+    * The resource will no longer attempt to resolve group members if Members, MembersToInclude, and MembersToExclude are not specified.
 
 ### 2.3.0.0
 

--- a/Tests/Integration/MSFT_GroupResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_GroupResource.Integration.Tests.ps1
@@ -26,10 +26,10 @@ try
             Import-Module -Name (Join-Path -Path $script:testHelpersPath `
                                            -ChildPath 'MSFT_GroupResource.TestHelper.psm1')
 
-            $script:confgurationWithMembersFilePath = Join-Path -Path $PSScriptRoot `
-                                                                -ChildPath 'MSFT_GroupResource_Members.config.ps1'
-            $script:confgurationWithMembersToIncludeExcludeFilePath = Join-Path -Path $PSScriptRoot `
-                                                                                -ChildPath 'MSFT_GroupResource_MembersToIncludeExclude.config.ps1'
+            $script:confgurationNoMembersFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_GroupResource_NoMembers.config.ps1'
+            $script:confgurationWithMembersFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_GroupResource_Members.config.ps1'
+            $script:confgurationWithMembersToIncludeExcludeFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_GroupResource_MembersToIncludeExclude.config.ps1'
+                                                                            
             # Fake users for testing
             $testUsername1 = 'TestUser1'
             $testUsername2 = 'TestUser2'
@@ -95,6 +95,47 @@ try
                     Remove-Group -GroupName $testGroupName
                 }
             }
+        }
+
+        It 'Should not change the state of the present built-in Users group when no Members specified' {
+            $configurationName = 'BuiltInGroup'
+            $testGroupName = 'Users'
+
+            $resourceParameters = @{
+                Ensure = 'Present'
+                GroupName = $testGroupName
+            }
+
+            Test-GroupExists -GroupName $testGroupName | Should Be $true
+
+            { 
+                . $script:confgurationNoMembersFilePath -ConfigurationName $configurationName
+                & $configurationName -OutputPath $TestDrive @resourceParameters
+                Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+            } | Should Not Throw
+
+            Test-GroupExists -GroupName $testGroupName | Should Be $true
+        }
+
+        It 'Should add a member to the built-in Users group with MembersToInclude' {
+            $configurationName = 'BuiltInGroup'
+            $testGroupName = 'Users'
+
+            $resourceParameters = @{
+                Ensure = 'Present'
+                GroupName = $testGroupName
+                MembersToInclude = $testUsername1
+            }
+
+            Test-GroupExists -GroupName $testGroupName | Should Be $true
+
+            { 
+                . $script:confgurationWithMembersToIncludeExcludeFilePath -ConfigurationName $configurationName
+                & $configurationName -OutputPath $TestDrive @resourceParameters
+                Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+            } | Should Not Throw
+
+            Test-GroupExists -GroupName $testGroupName -MembersToInclude $testUsername1 | Should Be $true
         }
 
         It 'Should create a group with two test users using Members' {

--- a/Tests/Integration/MSFT_GroupResource_NoMembers.config.ps1
+++ b/Tests/Integration/MSFT_GroupResource_NoMembers.config.ps1
@@ -1,0 +1,30 @@
+﻿param
+(
+    [Parameter(Mandatory = $true)]
+    [String]
+    $ConfigurationName
+)
+
+Configuration $ConfigurationName
+{
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $GroupName,
+
+        [ValidateSet('Present', 'Absent')]
+        [ValidateNotNullOrEmpty()]
+        [String]
+        $Ensure = 'Present'
+    )
+
+    Import-DscResource -ModuleName 'PSDscResources'
+
+    Group Group1
+    {
+        GroupName = $GroupName
+        Ensure = $Ensure
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
     - ps: Start-Sleep 5
     - ps: Restart-Computer -Force
     - ps: Start-Sleep 5
-    - ps: Write-Verbose -Message "Returned after restart with PSVersion $($PSVersionTable.PSVersion)"
+    - ps: Write-Verbose -Message "Returned after restart with PSVersion $($PSVersionTable.PSVersion)" -Verbose
     - ps: if ($PSVersionTable.PSVersion.Major -lt 5 -or $PSVersionTable.PSVersion.Minor -lt 1)
         {
             throw 'WMF 5.1 install failed'


### PR DESCRIPTION
This should fix #26, but I do not want to close that issue until the author has confirmed that this fix works for them as well.

There have been multiple issues opened about the error that the 'server names cannot contain a space character'. That was occurring because the resource was searching for a *domain* principal context for group members in the 'NT Authority' scope. The fix for this is to search for those users in the *machine* principal context instead. 

This PR also includes a fix in which the resource will no longer attempt to retrieve the group members when no members are specified.

I have added new integration tests for both cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/29)
<!-- Reviewable:end -->
