### PR TITLE
Group: Add NT Service to list of local scopes

### DIFF
--- a/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
+++ b/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
@@ -2156,7 +2156,7 @@ function Test-IsLocalMachine
         $Scope
     )
 
-    $localMachineScopes = @( '.', $env:computerName, 'localhost', '127.0.0.1', 'NT Authority' )
+    $localMachineScopes = @( '.', $env:computerName, 'localhost', '127.0.0.1', 'NT Authority', 'NT Service' )
 
     if ($localMachineScopes -icontains $Scope)
     {

--- a/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
+++ b/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
@@ -2156,7 +2156,7 @@ function Test-IsLocalMachine
         $Scope
     )
 
-    $localMachineScopes = @( '.', $env:computerName, 'localhost', '127.0.0.1', 'NT Authority', 'NT Service' )
+    $localMachineScopes = @( '.', $env:computerName, 'localhost', '127.0.0.1', 'NT Authority', 'NT Service', 'BuiltIn' )
 
     if ($localMachineScopes -icontains $Scope)
     {

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ The following parameters will be the same for each process in the set:
     * WindowsProcess: Minor updates to integration tests
     * Registry: Fixed support for forward slashes in registry key names
 * Group:
-    * Group members in the "NT Authority" and "NT Service" scopes should now be resolved without an error. If you were seeing the errors "Exception calling ".ctor" with "4" argument(s): "Server names cannot contain a space character."" or "Exception calling ".ctor" with "2" argument(s): "Server names cannot contain a space character."", this fix should resolve those errors. If you are still seeing one of the errors, there is probably another local scope we need to add. Please let us know.
+    * Group members in the "NT Authority", "BuiltIn" and "NT Service" scopes should now be resolved without an error. If you were seeing the errors "Exception calling ".ctor" with "4" argument(s): "Server names cannot contain a space character."" or "Exception calling ".ctor" with "2" argument(s): "Server names cannot contain a space character."", this fix should resolve those errors. If you are still seeing one of the errors, there is probably another local scope we need to add. Please let us know.
     * The resource will no longer attempt to resolve group members if Members, MembersToInclude, and MembersToExclude are not specified.
 * Added Environment
 

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ The following parameters will be the same for each process in the set:
     * WindowsProcess: Minor updates to integration tests
     * Registry: Fixed support for forward slashes in registry key names
 * Group:
-    * Group members in the "NT Authority" scope should now be resolved without an error. If you were seeing the error "Exception calling ".ctor" with "4" argument(s): "Server names cannot contain a space character."", this fix should resolve that error.
+    * Group members in the "NT Authority" and "NT Service" scopes should now be resolved without an error. If you were seeing the errors "Exception calling ".ctor" with "4" argument(s): "Server names cannot contain a space character."" or "Exception calling ".ctor" with "2" argument(s): "Server names cannot contain a space character."", this fix should resolve those errors. If you are still seeing one of the errors, there is probably another local scope we need to add. Please let us know.
     * The resource will no longer attempt to resolve group members if Members, MembersToInclude, and MembersToExclude are not specified.
 * Added Environment
 

--- a/Tests/Integration/MSFT_GroupResource_NoMembers.config.ps1
+++ b/Tests/Integration/MSFT_GroupResource_NoMembers.config.ps1
@@ -22,7 +22,7 @@ Configuration $ConfigurationName
 
     Import-DscResource -ModuleName 'PSDscResources'
 
-    Group Group1
+    Group Group3
     {
         GroupName = $GroupName
         Ensure = $Ensure


### PR DESCRIPTION
This is a local scope on database or SqlServer machines.
I can't add tests for it since I don't have either of those machines in our test environment, but it should fix any issues coming up with resolving NT Service members in a group.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/31)
<!-- Reviewable:end -->
