### PR TITLE
Added Support for domain based group members on Nano Server

### DIFF
--- a/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
+++ b/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
@@ -1522,6 +1522,7 @@ function Get-MembersOnNanoServer
         }
         else
         {
+            Write-Verbose -Message ($script:localizedData.MemberIsNotALocalUser -f $groupMember.Name,$groupMember.PrincipalSource)
             $domainMemberName = $groupMember.Name
             $null = $memberNames.Add($domainMemberName)
         }

--- a/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
+++ b/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
@@ -965,7 +965,7 @@ function Set-TargetResourceOnNanoServer
             }
             elseif ($PSBoundParameters.ContainsKey('MembersToInclude') -or $PSBoundParameters.ContainsKey('MembersToExclude'))
             {
-                $groupMembers = Get-MembersOnNanoServer -Group $group
+                [array]$groupMembers = Get-MembersOnNanoServer -Group $group
 
                 $uniqueMembersToInclude = $MembersToInclude | Select-Object -Unique
                 $uniqueMembersToExclude = $MembersToExclude | Select-Object -Unique
@@ -1419,7 +1419,7 @@ function Test-TargetResourceOnNanoServer
             }
         }
 
-        $groupMembers = Get-MembersOnNanoServer -Group $group
+        [array]$groupMembers = Get-MembersOnNanoServer -Group $group
 
         # Remove duplicate names as strings.
         $uniqueMembers = $Members | Select-Object -Unique
@@ -1498,7 +1498,7 @@ function Test-TargetResourceOnNanoServer
 #>
 function Get-MembersOnNanoServer
 {
-    [OutputType([System.String[]])]
+    [OutputType([System.Array[]])]
     [CmdletBinding()]
     param
     (
@@ -1508,7 +1508,7 @@ function Get-MembersOnNanoServer
         $Group
     )
 
-    $localMemberNames = New-Object -TypeName 'System.Collections.ArrayList'
+    $memberNames = New-Object -TypeName 'System.Collections.ArrayList'
 
     # Get the group members.
     $groupMembers = Get-LocalGroupMember -Group $Group
@@ -1518,16 +1518,16 @@ function Get-MembersOnNanoServer
         if ($groupMember.PrincipalSource -ieq 'Local')
         {
             $localMemberName = $groupMember.Name.Substring($groupMember.Name.IndexOf('\') + 1)
-            $null = $localMemberNames.Add($localMemberName)
+            $null = $memberNames.Add($localMemberName)
         }
         else
         {
-            Write-Verbose -Message ($script:localizedData.MemberIsNotALocalUser -f $groupMember.Name,
-                $groupMember.PrincipalSource)
+            $domainMemberName = $groupMember.Name
+            $null = $memberNames.Add($domainMemberName)
         }
     }
 
-    return $localMemberNames.ToArray()
+    return $memberNames.ToArray()
 }
 
 <#

--- a/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
+++ b/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
@@ -1498,7 +1498,7 @@ function Test-TargetResourceOnNanoServer
 #>
 function Get-MembersOnNanoServer
 {
-    [OutputType([System.Array[]])]
+    [OutputType([System.String[]])]
     [CmdletBinding()]
     param
     (

--- a/README.md
+++ b/README.md
@@ -504,6 +504,8 @@ The following parameters will be the same for each process in the set:
 ### Unreleased
 
 * Enable codecov.io code coverage reporting
+- Group
+    - Added support for domain based group members on Nano server.
 
 ### 2.4.0.0
 


### PR DESCRIPTION
Resolution for Issue [38](https://github.com/PowerShell/PSDscResources/issues/38)

Adds support for domain based group members on nano server.
This is a very important feature to be able to control the local administrators on a nano server without having GPOs/Restricted Groups.

If i missed anything i would gladly change :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/39)
<!-- Reviewable:end -->
