### PR TITLE
Fix Test-IsNanoServer to actually test for a NanoServer (Fixes #11)

### DIFF
--- a/DscResources/CommonResourceHelper.psm1
+++ b/DscResources/CommonResourceHelper.psm1
@@ -14,9 +14,11 @@ function Test-IsNanoServer
     {
         $computerInfo = Get-ComputerInfo
 
-        if ('Server' -eq $computerInfo.OsProductType -and 'NanoServer' -eq $computerInfo.OsServerLevel)
+        $computerIsServer = 'Server' -ieq $computerInfo.OsProductType
+
+        if ($computerIsServer)
         {
-            $isNanoServer = $true
+            $isNanoServer = 'NanoServer' -ieq $computerInfo.OsServerLevel
         }
     }
 

--- a/DscResources/CommonResourceHelper.psm1
+++ b/DscResources/CommonResourceHelper.psm1
@@ -8,7 +8,41 @@ function Test-IsNanoServer
     [CmdletBinding()]
     param ()
 
-    return $PSVersionTable.PSEdition -ieq 'Core'
+    $isNanoServer = $false
+    
+    if (Test-CommandExists -Name 'Get-ComputerInfo')
+    {
+        $computerInfo = Get-ComputerInfo
+
+        if ('Server' -eq $computerInfo.OsProductType -and 'NanoServer' -eq $computerInfo.OsServerLevel)
+        {
+            $isNanoServer = $true
+        }
+    }
+
+    return $isNanoServer
+}
+
+<#
+    .SYNOPSIS
+        Tests whether or not the command with the specified name exists.
+
+    .PARAMETER Name
+        The name of the command to test for.
+#>
+function Test-CommandExists
+{
+    [OutputType([Boolean])]
+    [CmdletBinding()]
+    param 
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullOrEmpty()]
+        [String] $Name 
+    )
+
+    $command = Get-Command -Name $Name -ErrorAction 'SilentlyContinue'
+    return ($null -ne $command)
 }
 
 <#

--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ The following parameters will be the same for each process in the set:
 * Group
     * Added support for domain based group members on Nano server.
 * Added the Archive resource
+* Update Test-IsNanoServer cmdlet to properly test for a Nano server rather than the core version of PowerShell
 
 ### 2.4.0.0
 

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -1,0 +1,175 @@
+﻿$errorActionPreference = 'Stop'
+Set-StrictMode -Version 'Latest'
+
+Describe 'CommonResourceHelper Unit Tests' {
+    BeforeAll {
+        # Import the CommonResourceHelper module to test
+        $testsFolderFilePath = Split-Path -Path $PSScriptRoot -Parent
+        $moduleRootFilePath = Split-Path -Path $testsFolderFilePath -Parent
+        $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
+        $commonResourceHelperFilePath = Join-Path -Path $dscResourcesFolderFilePath -ChildPath 'CommonResourceHelper.psm1'
+        Import-Module -Name $commonResourceHelperFilePath
+    }
+
+    InModuleScope 'CommonResourceHelper' {
+        Describe 'Test-IsNanoServer' {
+            $testComputerInfoNanoServer = @{
+                OsProductType = 'Server'
+                OsServerLevel = 'NanoServer'
+            }
+
+            $testComputerInfoServerNotNano = @{
+                OsProductType = 'Server'
+                OsServerLevel = 'NotNano'
+            }
+
+            $testComputerInfoNotServer = @{
+                OsProductType = 'NotServer'
+                OsServerLevel = 'NotNano'
+            }
+
+            Mock -CommandName 'Test-CommandExists' -MockWith { return $true }
+            Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoNanoServer }
+
+            Context 'Get-ComputerInfo command exists' {
+                Context 'Computer OS type is Server and OS server level is NanoServer' {
+                    It 'Should not throw' {
+                        { $null = Test-IsNanoServer } | Should Not Throw
+                    }
+
+                    It 'Should test if the Get-ComputerInfo command exists' {
+                        $testCommandExistsParameterFilter = {
+                            return $Name -eq 'Get-ComputerInfo'
+                        }
+
+                        Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should retrieve the computer info' {
+                        Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should return true' {
+                        Test-IsNanoServer | Should Be $true
+                    }
+                }
+
+                Context 'Computer OS type is Server and OS server level is not NanoServer' {
+                    Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoServerNotNano }
+                    
+                    It 'Should not throw' {
+                        { $null = Test-IsNanoServer } | Should Not Throw
+                    }
+
+                    It 'Should test if the Get-ComputerInfo command exists' {
+                        $testCommandExistsParameterFilter = {
+                            return $Name -eq 'Get-ComputerInfo'
+                        }
+
+                        Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should retrieve the computer info' {
+                        Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should return false' {
+                        Test-IsNanoServer | Should Be $false
+                    }
+                }
+
+                Context 'Computer OS type is not Server' {
+                    Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoNotServer }
+
+                    It 'Should not throw' {
+                        { $null = Test-IsNanoServer } | Should Not Throw
+                    }
+
+                    It 'Should test if the Get-ComputerInfo command exists' {
+                        $testCommandExistsParameterFilter = {
+                            return $Name -eq 'Get-ComputerInfo'
+                        }
+
+                        Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should retrieve the computer info' {
+                        Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 1 -Scope 'Context'
+                    }
+
+                    It 'Should return false' {
+                        Test-IsNanoServer | Should Be $false
+                    }
+                }
+            }
+
+            Context 'Get-ComputerInfo command does not exist' {
+                Mock -CommandName 'Test-CommandExists' -MockWith { return $false }
+
+                It 'Should not throw' {
+                    { $null = Test-IsNanoServer } | Should Not Throw
+                }
+
+                It 'Should test if the Get-ComputerInfo command exists' {
+                    $testCommandExistsParameterFilter = {
+                        return $Name -eq 'Get-ComputerInfo'
+                    }
+
+                    Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should not attempt to retrieve the computer info' {
+                    Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 0 -Scope 'Context'
+                }
+
+                It 'Should return false' {
+                    Test-IsNanoServer | Should Be $false
+                }
+            }
+        }
+
+        Describe 'Test-CommandExists' {
+            $testCommandName = 'TestCommandName'
+
+            Mock -CommandName 'Get-Command' -MockWith { return $Name }
+
+            Context 'Get-Command returns the command' {
+                It 'Should not throw' {
+                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                }
+
+                It 'Should retrieve the command with the specified name' {
+                    $getCommandParameterFilter = {
+                        return $Name -eq $testCommandName
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-Command' -ParameterFilter $getCommandParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should return true' {
+                    Test-CommandExists -Name $testCommandName | Should Be $true
+                }
+            }
+
+            Context 'Get-Command returns null' {
+                Mock -CommandName 'Get-Command' -MockWith { return $null }
+
+                It 'Should not throw' {
+                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                }
+
+                It 'Should retrieve the command with the specified name' {
+                    $getCommandParameterFilter = {
+                        return $Name -eq $testCommandName
+                    }
+
+                    Assert-MockCalled -CommandName 'Get-Command' -ParameterFilter $getCommandParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should return false' {
+                    Test-CommandExists -Name $testCommandName | Should Be $false
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
I have updated Test-IsNanoServer to correctly test for a Nano server rather than for the core version of PowerShell with the code provided in #11.

I have also added unit tests for both Test-IsNanoServer and the new common function Test-CommandExists.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/42)
<!-- Reviewable:end -->
