### PR TITLE
Registry: Fix Get-DscConfiguration

### DIFF
--- a/DscResources/MSFT_RegistryResource/MSFT_RegistryResource.psm1
+++ b/DscResources/MSFT_RegistryResource/MSFT_RegistryResource.psm1
@@ -66,6 +66,9 @@ function Get-TargetResource
     $registryResource = @{
         Key = $Key
         Ensure = 'Absent'
+        ValueName = $null
+        ValueType = $null
+        ValueData = $null
     }
 
     # Retrieve the registry key at the specified path
@@ -104,7 +107,7 @@ function Get-TargetResource
                 $actualValueType = Get-RegistryKeyValueType -RegistryKey $registryKey -RegistryKeyValueName $ValueName
 
                 # If the registry key value exists, convert it to a readable string
-                $registryKeyValueAsReadableString = ConvertTo-ReadableString -RegistryKeyValue $registryKeyValue -RegistryKeyValueType $actualValueType
+                $registryKeyValueAsReadableString = @() + (ConvertTo-ReadableString -RegistryKeyValue $registryKeyValue -RegistryKeyValueType $actualValueType)
 
                 $registryResource['Ensure'] = 'Present'
                 $registryResource['ValueType'] = $actualValueType

--- a/DscResources/MSFT_RegistryResource/MSFT_RegistryResource.psm1
+++ b/DscResources/MSFT_RegistryResource/MSFT_RegistryResource.psm1
@@ -66,9 +66,6 @@ function Get-TargetResource
     $registryResource = @{
         Key = $Key
         Ensure = 'Absent'
-        ValueName = $null
-        ValueType = $null
-        ValueData = $null
     }
 
     # Retrieve the registry key at the specified path

--- a/README.md
+++ b/README.md
@@ -541,6 +541,8 @@ The following parameters will be the same for each process in the set:
     * Added support for domain based group members on Nano server.
 * Added the Archive resource
 * Update Test-IsNanoServer cmdlet to properly test for a Nano server rather than the core version of PowerShell
+* Registry
+    * Fixed bug where an error was thrown when running Get-DscConfiguration if the registry already existed
 
 ### 2.4.0.0
 

--- a/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
@@ -24,8 +24,6 @@ $script:testEnvironment = Enter-DscResourceTestEnvironment `
     -DscResourceName 'MSFT_RegistryResource' `
     -TestType 'Integration'
 
-$VerbosePreference = 'Continue'
-
 try
 {
     Describe 'Registry End to End Tests' {
@@ -353,7 +351,6 @@ try
 }
 finally
 {
-    $VerbosePreference = 'SilentlyContinue'
     Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
 }
         

--- a/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
@@ -24,6 +24,8 @@ $script:testEnvironment = Enter-DscResourceTestEnvironment `
     -DscResourceName 'MSFT_RegistryResource' `
     -TestType 'Integration'
 
+$VerbosePreference = 'Continue'
+
 try
 {
     Describe 'Registry End to End Tests' {
@@ -92,6 +94,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have created the registry key value' {
@@ -124,6 +130,10 @@ try
                     & $configurationName -OutputPath $TestDrive @registryParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
                 } | Should Not Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
 
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
@@ -182,6 +192,10 @@ try
                     } | Should Not Throw
                 }
 
+                It 'Should be able to call Get-DscConfiguration without throwing' {
+                    { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+                }
+
                 $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
                 It 'Should be able to retrieve the registry key value' {
@@ -219,6 +233,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should be able to retrieve the registry key value' {
@@ -251,6 +269,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the registry key value' {
@@ -281,6 +303,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the registry key value' {
@@ -309,6 +335,10 @@ try
                 } | Should Not Throw
             }
 
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
             $registryKey = Get-Item -Path $registryParameters.Key -ErrorAction 'SilentlyContinue'
 
             It 'Should have removed the registry key value' {
@@ -323,6 +353,7 @@ try
 }
 finally
 {
+    $VerbosePreference = 'SilentlyContinue'
     Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
 }
         


### PR DESCRIPTION
Fixed a bug in which Registry would always throw an error when Get-DscConfiguration was called if the registry key already existed.

Also added tests to make sure Get-DscConfiguration works for Registry.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/44)
<!-- Reviewable:end -->
