### PR TITLE
Verify InstalledOn date in correct culture in MSFT_MsiPackage unit test

### DIFF
--- a/DscResources/MSFT_MsiPackage/MSFT_MsiPackage.psm1
+++ b/DscResources/MSFT_MsiPackage/MSFT_MsiPackage.psm1
@@ -626,7 +626,7 @@ function Get-ProductEntryInfo
     {
         try
         {
-            $installDate = '{0:d}' -f [DateTime]::ParseExact($installDate, 'yyyyMMdd',[System.Globalization.CultureInfo]::CurrentCulture).Date
+            $installDate = '{0:d}' -f [DateTime]::ParseExact($installDate, 'yyyyMMdd',[System.Globalization.CultureInfo]::InvariantCulture).Date
         }
         catch
         {

--- a/Tests/Unit/MSFT_MsiPackage.Tests.ps1
+++ b/Tests/Unit/MSFT_MsiPackage.Tests.ps1
@@ -57,7 +57,7 @@ Describe 'MsiPackage Unit Tests' {
         $script:mockProductEntryInfo = @{
             Name = 'TestDisplayName'
             InstallSource = 'TestInstallSource'
-            InstalledOn = '4/4/2017'
+            InstalledOn = ([DateTime]::new(2017, 4, 24).ToShortDateString())
             Size = 2048
             Version = '1.2.3.4'
             PackageDescription = 'Test Description'
@@ -586,7 +586,7 @@ Describe 'MsiPackage Unit Tests' {
         }
 
         Describe 'Get-ProductEntryInfo' {
-            Mock -CommandName Get-ProductEntryValue -MockWith { return '20170404' } -ParameterFilter { $Property -eq 'InstallDate' }
+            Mock -CommandName Get-ProductEntryValue -MockWith { return '20170424' } -ParameterFilter { $Property -eq 'InstallDate' }
             Mock -CommandName Get-ProductEntryValue -MockWith { return $script:mockProductEntryInfo.Publisher } -ParameterFilter { $Property -eq 'Publisher' }
             Mock -CommandName Get-ProductEntryValue -MockWith { return $script:mockProductEntryInfo.Size } -ParameterFilter { $Property -eq 'EstimatedSize' }
             Mock -CommandName Get-ProductEntryValue -MockWith { return $script:mockProductEntryInfo.Version } -ParameterFilter { $Property -eq 'DisplayVersion' }


### PR DESCRIPTION
Hello,
I found out that a unit-test in MSFT_MsiPackage.Tests.ps1 fails on a computer with non-English regional settings. The failing unit-test is:
- Describing Get-ProductEntryInfo
- Context All properties are retrieved successfully
- Should return the expected installed date

The problem is that it asserts date formatted in en-US culture.
So I changed the test that it asserts date formatted in current culture.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/54)
<!-- Reviewable:end -->
