### PR TITLE
Archive: Add handling for directory archive entries ending with a forward slash (Fixes #67)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 DSCResource.Tests
+*.vscode

--- a/README.md
+++ b/README.md
@@ -577,6 +577,9 @@ The following parameters will be the same for each process in the set:
 
 ### Unreleased
 
+* Archive:
+    * Added handling of directory archive entries that end with a foward slash
+
 ### 2.7.0.0
 
 * MsiPackage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@
 #      environment configuration  #
 #---------------------------------#
 version: 2.4.{build}.0
-os: Previous Visual Studio 2015
+os: Visual Studio 2015
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests
     - ps: Import-Module -Name .\Tests\TestHelpers\WMF5Dot1Installation.psm1 -Force


### PR DESCRIPTION
Directory archive entries can end in either a backslash or a forward slash. The resource was only handling the backslash and crashing on the forward slash case, so I added handling for the forward slash.

I have added new unit tests for this as well, but I'm not sure how to dynamically create an archive with directory archive entries that end in forward slashes on a Windows machine, so integration testing was not added for this case.

I have also added the import of Microsoft.PowerShell.Utility to the resource as it could not find the function Get-FileHash on a Windows 10 machine with the Creators  Update.

This should fix #67.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/72)
<!-- Reviewable:end -->
