### PR TITLE
Fix Archive culture problems with timestamp

### DIFF
--- a/DscResources/MSFT_Archive/MSFT_Archive.psm1
+++ b/DscResources/MSFT_Archive/MSFT_Archive.psm1
@@ -944,10 +944,6 @@ function Test-FileHashMatchesArchiveEntryHash
 
     .PARAMETER Checksum
         The checksum method to retrieve the timestamp for.
-
-    .NOTES
-        The returned date is normalized to the General (G) date format.
-        https://technet.microsoft.com/en-us/library/ee692801.aspx
 #>
 function Get-TimestampForChecksum
 {
@@ -970,11 +966,11 @@ function Get-TimestampForChecksum
 
     if ($Checksum -ieq 'CreatedDate')
     {
-        $relevantTimestamp = Get-Date -Date $File.CreationTime.DateTime -Format 'G'
+        $relevantTimestamp = $File.CreationTime.DateTime
     }
     elseif ($Checksum -ieq 'ModifiedDate')
     {
-        $relevantTimestamp = Get-Date -Date $File.LastWriteTime.DateTime -Format 'G'
+        $relevantTimestamp = $File.LastWriteTime.DateTime
     }
 
     return $relevantTimestamp
@@ -987,10 +983,6 @@ function Get-TimestampForChecksum
 
     .PARAMETER ArchiveEntry
         The archive entry to retrieve the last write time of.
-
-    .NOTES
-        The returned date is normalized to the General (G) date format.
-        https://technet.microsoft.com/en-us/library/ee692801.aspx
 #>
 function Get-ArchiveEntryLastWriteTime
 {
@@ -1004,7 +996,7 @@ function Get-ArchiveEntryLastWriteTime
         $ArchiveEntry
     )
 
-    return (Get-Date -Date $ArchiveEntry.LastWriteTime.DateTime -Format 'G')
+    return $ArchiveEntry.LastWriteTime.DateTime
 }
 
 <#
@@ -1320,7 +1312,7 @@ function Copy-ArchiveEntryToDestination
             }
         }
 
-        $newArchiveFileInfo = New-Object -TypeName 'System.IO.FileInfo' -ArgumentList @( $DestinationPath )
+        $null = New-Object -TypeName 'System.IO.FileInfo' -ArgumentList @( $DestinationPath )
 
         $updatedTimestamp = Get-ArchiveEntryLastWriteTime -ArchiveEntry $ArchiveEntry
 

--- a/DscResources/MSFT_Archive/MSFT_Archive.psm1
+++ b/DscResources/MSFT_Archive/MSFT_Archive.psm1
@@ -12,11 +12,15 @@ $script:dscResourcesFolderFilePath = Split-Path $PSScriptRoot -Parent
 $script:commonResourceHelperFilePath = Join-Path -Path $script:dscResourcesFolderFilePath -ChildPath 'CommonResourceHelper.psm1'
 Import-Module -Name $script:commonResourceHelperFilePath
 
-# Import Microsoft.PowerShell.Utility for Get-FileHash
-Import-Module -Name 'Microsoft.PowerShell.Utility'
-
 # Localized messages for verbose and error statements in this resource
 $script:localizedData = Get-LocalizedData -ResourceName 'MSFT_Archive'
+
+# Import Microsoft.PowerShell.Utility for Get-FileHash
+$fileHashCommand = Get-Command -Name 'Get-FileHash' -Module 'Microsoft.PowerShell.Utility' -ErrorAction 'SilentlyContinue'
+if ($null -eq $fileHashCommand)
+{
+    Import-Module -Name 'Microsoft.PowerShell.Utility' -Function 'Get-FileHash'
+}
 
 Add-Type -AssemblyName 'System.IO.Compression'
 
@@ -1063,7 +1067,7 @@ function Test-FileMatchesArchiveEntryByChecksum
 
         $archiveEntryLastWriteTime = Get-ArchiveEntryLastWriteTime -ArchiveEntry $ArchiveEntry
 
-        if ($fileTimestampForChecksum.Equals($archiveEntryLastWriteTime))
+        if ([DateTime]$fileTimestampForChecksum -eq [DateTime]$archiveEntryLastWriteTime)
         {
             Write-Verbose -Message ($script:localizedData.FileMatchesArchiveEntryByChecksum -f $File.FullName, $archiveEntryFullName, $Checksum)
 

--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ The following parameters will be the same for each process in the set:
 
 * Archive:
     * Added handling of directory archive entries that end with a foward slash
+    * Removed formatting of LastWriteTime timestamp and updated comparison of timestamps to handle dates in different formats
 * WindowsProcess:
     * Fix unreliable tests
 * Updated Test-IsNanoServer to return false if Get-ComputerInfo fails

--- a/Tests/Integration/MSFT_Archive.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_Archive.EndToEnd.Tests.ps1
@@ -131,7 +131,7 @@ Describe 'Archive End to End Tests' {
     }
 
     AfterAll {
-        Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
+        $null = Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
     }
 
     Context 'Expand an archive to a destination that does not yet exist' {

--- a/Tests/Integration/MSFT_Archive.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_Archive.Integration.Tests.ps1
@@ -22,11 +22,11 @@ Describe 'Archive Integration Tests' {
 
         # Import archive test helper for New-ZipFileFromHashtable, Test-FileStructuresMatch
         $archiveTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'MSFT_Archive.TestHelper.psm1'
-        Import-Module -Name $archiveTestHelperFilePath -Force
+        Import-Module -Name $archiveTestHelperFilePath
     }
 
     AfterAll {
-        Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
+        $null = Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
     }
 
     Context 'Expand a basic archive' {
@@ -40,12 +40,13 @@ Describe 'Archive Integration Tests' {
         }
 
         $zipFilePath = New-ZipFileFromHashtable -Name $zipFileName -ParentPath $TestDrive -ZipFileStructure $zipFileStructure
+        $zipFileSourcePath = $zipFilePath.Replace('.zip', '')
 
         $destinationDirectoryName = 'ExpandBasicArchive'
         $destinationDirectoryPath = Join-Path -Path $TestDrive -ChildPath $destinationDirectoryName
 
         It 'File structure and contents of the destination should not match the file structure and contents of the archive before Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
         }
 
         It 'Test-TargetResource with Ensure as Present should return false before Set-TargetResource' {
@@ -61,7 +62,7 @@ Describe 'Archive Integration Tests' {
         }
 
         It 'File structure and contents of the destination should match the file structure and contents of the archive after Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
         }
 
         It 'Test-TargetResource with Ensure as Present should return true after Set-TargetResource' {
@@ -84,6 +85,7 @@ Describe 'Archive Integration Tests' {
         }
 
         $zipFilePath = New-ZipFileFromHashtable -Name $zipFileName -ParentPath $TestDrive -ZipFileStructure $zipFileStructure
+        $zipFileSourcePath = $zipFilePath.Replace('.zip', '')
 
         $destinationDirectoryName = 'RemoveBasicArchive'
         $destinationDirectoryPath = Join-Path -Path $TestDrive -ChildPath $destinationDirectoryName
@@ -91,7 +93,7 @@ Describe 'Archive Integration Tests' {
         $null = Expand-Archive -Path $zipFilePath -DestinationPath $destinationDirectoryPath -Force
 
         It 'File structure and contents of the destination should match the file structure and contents of the archive before Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
         }
 
         It 'Test-TargetResource with Ensure as Present should return true before Set-TargetResource' {
@@ -107,7 +109,7 @@ Describe 'Archive Integration Tests' {
         }
 
         It 'File structure and contents of the destination should not match the file structure and contents of the archive after Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
         }
 
         It 'Test-TargetResource with Ensure as Present should return false after Set-TargetResource' {
@@ -156,12 +158,13 @@ Describe 'Archive Integration Tests' {
         }
 
         $zipFilePath = New-ZipFileFromHashtable -Name $zipFileName -ParentPath $TestDrive -ZipFileStructure $zipFileStructure
+        $zipFileSourcePath = $zipFilePath.Replace('.zip', '')
 
         $destinationDirectoryName = 'ExpandNestedArchive'
         $destinationDirectoryPath = Join-Path -Path $TestDrive -ChildPath $destinationDirectoryName
 
         It 'File structure and contents of the destination should not match the file structure and contents of the archive before Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
         }
 
         It 'Test-TargetResource with Ensure as Present should return false before Set-TargetResource' {
@@ -177,7 +180,7 @@ Describe 'Archive Integration Tests' {
         }
 
         It 'File structure and contents of the destination should match the file structure and contents of the archive after Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
         }
 
         It 'Test-TargetResource with Ensure as Present should return true after Set-TargetResource' {
@@ -226,6 +229,7 @@ Describe 'Archive Integration Tests' {
         }
 
         $zipFilePath = New-ZipFileFromHashtable -Name $zipFileName -ParentPath $TestDrive -ZipFileStructure $zipFileStructure
+        $zipFileSourcePath = $zipFilePath.Replace('.zip', '')
 
         $destinationDirectoryName = 'RemoveNestedArchive'
         $destinationDirectoryPath = Join-Path -Path $TestDrive -ChildPath $destinationDirectoryName
@@ -233,7 +237,7 @@ Describe 'Archive Integration Tests' {
         $null = Expand-Archive -Path $zipFilePath -DestinationPath $destinationDirectoryPath -Force
 
         It 'File structure and contents of the destination should match the file structure and contents of the archive before Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
         }
 
         It 'Test-TargetResource with Ensure as Present should return true before Set-TargetResource' {
@@ -249,7 +253,7 @@ Describe 'Archive Integration Tests' {
         }
 
         It 'File structure and contents of the destination should not match the file structure and contents of the archive after Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
         }
 
         It 'Test-TargetResource with Ensure as Present should return false after Set-TargetResource' {
@@ -271,6 +275,7 @@ Describe 'Archive Integration Tests' {
         }
 
         $zipFilePath1 = New-ZipFileFromHashtable -Name $zipFileName1 -ParentPath $TestDrive -ZipFileStructure $zipFileStructure1
+        $zipFileSourcePath1 = $zipFilePath1.Replace('.zip', '')
 
         $zipFileName2 = 'SameTimestamp2'
 
@@ -290,7 +295,7 @@ Describe 'Archive Integration Tests' {
         $destinationDirectoryPath = Join-Path -Path $TestDrive -ChildPath $destinationDirectoryName
 
         It 'File structure and contents of the destination should not match the file structure and contents of the archive before Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath1.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath1 -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
         }
 
         It 'Test-TargetResource with Ensure as Present should return false for specified archive before Set-TargetResource' {
@@ -314,7 +319,7 @@ Describe 'Archive Integration Tests' {
         }
 
         It 'File structure and contents of the destination should match the file structure and contents of the archive after Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath1.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath1 -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
         }
 
         It 'Test-TargetResource with Ensure as Present should return true for specified archive after Set-TargetResource' {
@@ -354,6 +359,7 @@ Describe 'Archive Integration Tests' {
         }
 
         $zipFilePath = New-ZipFileFromHashtable -Name $zipFileName -ParentPath $TestDrive -ZipFileStructure $zipFileStructure
+        $zipFileSourcePath = $zipFilePath.Replace('.zip', '')
 
         $destinationDirectoryName = 'RemoveArchiveWithExtra'
         $destinationDirectoryPath = Join-Path -Path $TestDrive -ChildPath $destinationDirectoryName
@@ -365,7 +371,7 @@ Describe 'Archive Integration Tests' {
         $null = Set-Content -Path $newFilePath -Value 'Fake text'
 
         It 'File structure and contents of the destination should match the file structure and contents of the archive before Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
         }
 
         It 'Test-TargetResource with Ensure as Present should return true before Set-TargetResource' {
@@ -385,7 +391,7 @@ Describe 'Archive Integration Tests' {
         }
         
         It 'File structure and contents of the destination should not match the file structure and contents of the archive after Set-TargetResource' {
-            Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+            Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
         }
 
         It 'Test-TargetResource with Ensure as Present should return false after Set-TargetResource' {
@@ -413,6 +419,7 @@ Describe 'Archive Integration Tests' {
     }
 
     $zipFilePath = New-ZipFileFromHashtable -Name $zipFileName -ParentPath $TestDrive -ZipFileStructure $zipFileStructure
+    $zipFileSourcePath = $zipFilePath.Replace('.zip', '')
 
     foreach ($possibleChecksumValue in $possibleChecksumValues)
     {        
@@ -432,7 +439,7 @@ Describe 'Archive Integration Tests' {
                 try
                 {
                     $matchingArchiveEntry = $archive.Entries | Where-Object -FilterScript {$_.FullName -eq $correspondingZipItemPath }
-                    $archiveEntryLastWriteTime = Get-Date -Date $matchingArchiveEntry.LastWriteTime.DateTime -Format 'G'
+                    $archiveEntryLastWriteTime = $matchingArchiveEntry.LastWriteTime.DateTime
                 }
                 finally
                 {
@@ -457,10 +464,6 @@ Describe 'Archive Integration Tests' {
                 Test-Path -Path $fileToEditPath | Should Be $true
             }
 
-            $fileBeforeEdit = Get-Item -Path $fileToEditPath
-            $lastWriteTimeBeforeEdit = $fileBeforeEdit.LastWriteTime
-            $creationTimeBeforeEdit = $fileBeforeEdit.CreationTime
-
             $null = Set-Content -Path $fileToEditPath -Value 'Different false text' -Force
             Set-ItemProperty -Path $fileToEditPath -Name 'LastWriteTime' -Value ([DateTime]::MaxValue)
             Set-ItemProperty -Path $fileToEditPath -Name 'CreationTime' -Value ([DateTime]::MaxValue)
@@ -472,11 +475,11 @@ Describe 'Archive Integration Tests' {
             }
 
             It 'Edited file at the destination should have different last write time than the same file in the archive before Set-TargetResource' {
-                $fileAfterEdit.LastWriteTime | Should Not Be $lastWriteTimeBeforeEdit
+                [DateTime]($fileAfterEdit.LastWriteTime.DateTime) -eq [DateTime]($archiveEntryLastWriteTime) | Should Be $false
             }
 
             It 'Edited file at the destination should have different creation time than the last write time of the the same file in the archive before Set-TargetResource' {
-                $fileAfterEdit.CreationTime | Should Not Be $lastWriteTimeBeforeEdit
+                $fileAfterEdit.CreationTime | Should Not Be $archiveEntryLastWriteTime
             }
 
             It 'Test-TargetResource with Ensure as Present should return false before Set-TargetResource' {
@@ -488,14 +491,12 @@ Describe 'Archive Integration Tests' {
             }
 
             It 'File structure and contents of the destination should not match the file structure and contents of the archive before Set-TargetResource' {
-                Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+                Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
             }
 
             It 'Set-TargetResource should not throw' {
                 { Set-TargetResource -Ensure 'Present' -Path $zipFilePath -Destination $destinationDirectoryPath -Validate $true -Checksum $possibleChecksumValue -Force $true } | Should Not Throw
             }
-
-            $fileAfterSetTargetResource = Get-Item -Path $fileToEditPath
 
             It 'Edited file should exist at the destination after Set-TargetResource' {
                 Test-Path -Path $fileToEditPath | Should Be $true
@@ -505,12 +506,14 @@ Describe 'Archive Integration Tests' {
                 Get-Content -Path $fileToEditPath -Raw | Should Be ($zipFileStructure[$fileToEditName] + "`r`n")
             }
 
+            $fileAfterSetTargetResource = Get-Item -Path $fileToEditPath
+
             It 'Edited file at the destination should have the same last write time as the same file in the archive after Set-TargetResource' {
-                $fileAfterSetTargetResource.LastWriteTime | Should Be $lastWriteTimeBeforeEdit
+                [DateTime]($fileAfterSetTargetResource.LastWriteTime.DateTime) -eq [DateTime]($archiveEntryLastWriteTime) | Should Be $true
             }
 
             It 'Edited file at the destination should have the same creation time as last write time of the the same file in the archive after Set-TargetResource' {
-                $fileAfterSetTargetResource.CreationTime | Should Be $lastWriteTimeBeforeEdit
+                [DateTime]($fileAfterSetTargetResource.CreationTime.DateTime) -eq [DateTime]($archiveEntryLastWriteTime) | Should Be $true
             }
 
             It 'Test-TargetResource with Ensure as Present should return true after Set-TargetResource' {
@@ -522,7 +525,7 @@ Describe 'Archive Integration Tests' {
             }
 
             It 'File structure and contents of the destination should match the file structure and contents of the archive after Set-TargetResource' {
-                Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
+                Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $true
             }
         }
 
@@ -542,7 +545,7 @@ Describe 'Archive Integration Tests' {
                 try
                 {
                     $matchingArchiveEntry = $archive.Entries | Where-Object -FilterScript {$_.FullName -eq $correspondingZipItemPath }
-                    $archiveEntryLastWriteTime = Get-Date -Date $matchingArchiveEntry.LastWriteTime.DateTime -Format 'G'
+                    $archiveEntryLastWriteTime = $matchingArchiveEntry.LastWriteTime.DateTime
                 }
                 finally
                 {
@@ -567,10 +570,6 @@ Describe 'Archive Integration Tests' {
                 Test-Path -Path $fileToEditPath | Should Be $true
             }
 
-            $fileBeforeEdit = Get-Item -Path $fileToEditPath
-            $lastWriteTimeBeforeEdit = $fileBeforeEdit.LastWriteTime
-            $creationTimeBeforeEdit = $fileBeforeEdit.CreationTime
-
             $null = Set-Content -Path $fileToEditPath -Value 'Different false text' -Force
             Set-ItemProperty -Path $fileToEditPath -Name 'LastWriteTime' -Value ([DateTime]::MaxValue)
             Set-ItemProperty -Path $fileToEditPath -Name 'CreationTime' -Value ([DateTime]::MaxValue)
@@ -582,11 +581,11 @@ Describe 'Archive Integration Tests' {
             }
 
             It 'Edited file at the destination should have different last write time than the same file in the archive before Set-TargetResource' {
-                $fileAfterEdit.LastWriteTime | Should Not Be $lastWriteTimeBeforeEdit
+                [DateTime]($fileAfterEdit.LastWriteTime.DateTime) -eq [DateTime]($archiveEntryLastWriteTime) | Should Be $false 
             }
 
             It 'Edited file at the destination should have different creation time than the last write time of the the same file in the archive before Set-TargetResource' {
-                $fileAfterEdit.CreationTime | Should Not Be $lastWriteTimeBeforeEdit
+                $fileAfterEdit.CreationTime.DateTime -eq $archiveEntryLastWriteTime | Should Be $false
             }
 
             It 'Test-TargetResource with Ensure as Present should return false before Set-TargetResource' {
@@ -598,10 +597,12 @@ Describe 'Archive Integration Tests' {
             }
 
             It 'File structure and contents of the destination should not match the file structure and contents of the archive before Set-TargetResource' {
-                Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+                Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
             }
 
-            { Set-TargetResource -Ensure 'Present' -Path $zipFilePath -Destination $destinationDirectoryPath -Validate $true -Checksum $possibleChecksumValue } | Should Throw
+            It 'Set-TargetResource should throw an error that the resource cannot overwrite the destination without Force specified' {
+                { Set-TargetResource -Ensure 'Present' -Path $zipFilePath -Destination $destinationDirectoryPath -Validate $true -Checksum $possibleChecksumValue } | Should Throw
+            }
         }
 
         Context "Remove an archive with an edited file, Validate specified, and Checksum specified as $possibleChecksumValue" {
@@ -620,7 +621,7 @@ Describe 'Archive Integration Tests' {
                 try
                 {
                     $matchingArchiveEntry = $archive.Entries | Where-Object -FilterScript {$_.FullName -eq $correspondingZipItemPath }
-                    $archiveEntryLastWriteTime = Get-Date -Date $matchingArchiveEntry.LastWriteTime.DateTime -Format 'G'
+                    $archiveEntryLastWriteTime = $matchingArchiveEntry.LastWriteTime.DateTime
                 }
                 finally
                 {
@@ -645,13 +646,9 @@ Describe 'Archive Integration Tests' {
                 Test-Path -Path $fileToEditPath | Should Be $true
             }
 
-            $fileBeforeEdit = Get-Item -Path $fileToEditPath
-            $lastWriteTimeBeforeEdit = $fileBeforeEdit.LastWriteTime
-            $creationTimeBeforeEdit = $fileBeforeEdit.CreationTime
-
             $null = Set-Content -Path $fileToEditPath -Value 'Different false text' -Force
-            Set-ItemProperty -Path $fileToEditPath -Name 'LastWriteTime' -Value ([DateTime]::MaxValue)
-            Set-ItemProperty -Path $fileToEditPath -Name 'CreationTime' -Value ([DateTime]::MaxValue)
+            $null = Set-ItemProperty -Path $fileToEditPath -Name 'LastWriteTime' -Value ([DateTime]::MaxValue)
+            $null = Set-ItemProperty -Path $fileToEditPath -Name 'CreationTime' -Value ([DateTime]::MaxValue)
 
             $fileAfterEdit = Get-Item -Path $fileToEditPath
 
@@ -660,11 +657,11 @@ Describe 'Archive Integration Tests' {
             }
 
             It 'Edited file at the destination should have different last write time than the same file in the archive after file edit and before Set-TargetResource' {
-                $fileAfterEdit.LastWriteTime | Should Not Be $lastWriteTimeBeforeEdit
+                [DateTime]($fileAfterEdit.LastWriteTime.DateTime) -eq [DateTime]($archiveEntryLastWriteTime) | Should Be $false
             }
 
             It 'Edited file at the destination should have different creation time than the last write time of the the same file in the archive after file edit before Set-TargetResource' {
-                $fileAfterEdit.CreationTime | Should Not Be $lastWriteTimeBeforeEdit
+                $fileAfterEdit.CreationTime.DateTime -eq $archiveEntryLastWriteTime | Should Be $false
             }
 
             It 'Test-TargetResource with Ensure as Present should return false before Set-TargetResource' {
@@ -676,14 +673,12 @@ Describe 'Archive Integration Tests' {
             }
 
             It 'File structure and contents of the destination should not match the file structure and contents of the archive before Set-TargetResource' {
-                Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+                Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
             }
 
             It 'Set-TargetResource should not throw' {
                 { Set-TargetResource -Ensure 'Absent' -Path $zipFilePath -Destination $destinationDirectoryPath -Validate $true -Checksum $possibleChecksumValue } | Should Not Throw
             }
-
-            $fileAfterSetTargetResource = Get-Item -Path $fileToEditPath
 
             It 'Edited file should exist at the destination after Set-TargetResource' {
                 Test-Path -Path $fileToEditPath | Should Be $true
@@ -693,12 +688,14 @@ Describe 'Archive Integration Tests' {
                 Get-Content -Path $fileToEditPath -Raw | Should Be ('Different false text' + "`r`n")
             }
 
+            $fileAfterSetTargetResource = Get-Item -Path $fileToEditPath
+
             It 'Edited file at the destination should have different last write time than the same file in the archive after Set-TargetResource' {
-                $fileAfterEdit.LastWriteTime | Should Not Be $lastWriteTimeBeforeEdit
+                [DateTime]($fileAfterSetTargetResource.LastWriteTime.DateTime) -eq [DateTime]($archiveEntryLastWriteTime) | Should Be $false
             }
 
             It 'Edited file at the destination should have different creation time than the last write time of the the same file in the archive after Set-TargetResource' {
-                $fileAfterEdit.CreationTime | Should Not Be $lastWriteTimeBeforeEdit
+                $fileAfterSetTargetResource.CreationTime.DateTime -eq $archiveEntryLastWriteTime | Should Be $false
             }
 
             It 'Test-TargetResource with Ensure as Present should return false after Set-TargetResource' {
@@ -710,7 +707,7 @@ Describe 'Archive Integration Tests' {
             }
 
             It 'File structure and contents of the destination should not match the file structure and contents of the archive after Set-TargetResource' {
-                Test-FileStructuresMatch -SourcePath $zipFilePath.Replace('.zip', '') -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
+                Test-FileStructuresMatch -SourcePath $zipFileSourcePath -DestinationPath $destinationDirectoryPath -CheckContents | Should Be $false
             }
         }
     }

--- a/Tests/Unit/MSFT_Archive.Tests.ps1
+++ b/Tests/Unit/MSFT_Archive.Tests.ps1
@@ -16,7 +16,7 @@ Describe 'Archive Unit Tests' {
     }
 
     AfterAll {
-        Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
+        $null = Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
     }
 
     InModuleScope 'MSFT_Archive' {
@@ -2095,14 +2095,10 @@ Describe 'Archive Unit Tests' {
         }
 
         Describe 'Get-TimestampForChecksum' {
-            
-
             # This is the actual file info of this file since we cannot set the properties of mock objects
             $testFileInfo = New-Object -TypeName 'System.IO.FileInfo' -ArgumentList @( $PSScriptRoot )
-            $testFileCreationTime = (Get-Date -Date $testFileInfo.CreationTime.DateTime -Format 'G')
-            $testFileLastWriteTime = (Get-Date -Date $testFileInfo.LastWriteTime.DateTime -Format 'G')
-
-            Mock -CommandName 'Get-Date' -MockWith { return $testFileCreationTime }
+            $testFileCreationTime = $testFileInfo.CreationTime.DateTime
+            $testFileLastWriteTime = $testFileInfo.LastWriteTime.DateTime
 
             Context 'Checksum specified as CreatedDate' {
                 $getTimestampForChecksumParameters = @{
@@ -2114,23 +2110,10 @@ Describe 'Archive Unit Tests' {
                     { $null = Get-TimestampForChecksum @getTimestampForChecksumParameters } | Should Not Throw
                 }
 
-                It 'Should normalize the date to the General (G) format' {
-                    $getDateParameterFilter = {
-                        $dateParameterCorrect = $Date -eq $testFileCreationTime
-                        $formatParameterCorrect = $Format -eq 'G'
-
-                        return $dateParameterCorrect -and $formatParameterCorrect
-                    }
-
-                    Assert-MockCalled -CommandName 'Get-Date' -ParameterFilter $getDateParameterFilter -Exactly 1 -Scope 'Context'
-                }
-
                 It 'Should return the creation time of the file' {
                     Get-TimestampForChecksum @getTimestampForChecksumParameters | Should Be $testFileCreationTime
                 }
             }
-
-            Mock -CommandName 'Get-Date' -MockWith { return $testFileLastWriteTime }
 
             Context 'Checksum specified as ModifiedDate' {
                 $getTimestampForChecksumParameters = @{
@@ -2140,17 +2123,6 @@ Describe 'Archive Unit Tests' {
 
                 It 'Should not throw' {
                     { $null = Get-TimestampForChecksum @getTimestampForChecksumParameters } | Should Not Throw
-                }
-
-                It 'Should normalize the date to the General (G) format' {
-                    $getDateParameterFilter = {
-                        $dateParameterCorrect = $Date -eq $testFileLastWriteTime
-                        $formatParameterCorrect = $Format -eq 'G'
-
-                        return $dateParameterCorrect -and $formatParameterCorrect
-                    }
-
-                    Assert-MockCalled -CommandName 'Get-Date' -ParameterFilter $getDateParameterFilter -Exactly 1 -Scope 'Context'
                 }
 
                 It 'Should return the last write time of the file' {
@@ -2482,7 +2454,6 @@ Describe 'Archive Unit Tests' {
         Describe 'Test-ArchiveExistsAtDestination' {
             $testArchiveEntryFullName = 'TestArchiveEntryFullName'
             $testItemPathAtDestination = 'TestItemPathAtDestination'
-            $testParentDirectoryPath = 'TestParentDirectoryPath'
 
             $mockArchive = New-MockObject -Type 'System.IO.Compression.ZipArchive'
             $mockArchiveEntry = New-MockObject -Type 'System.IO.Compression.ZipArchiveEntry'
@@ -4898,7 +4869,7 @@ Describe 'Archive Unit Tests' {
                         return $fileParameterCorrect -and $archiveEntryParameterCorrect -and $checksumParameterCorrect
                     }
                     
-                    Assert-MockCalled -CommandName 'Test-FileMatchesArchiveEntryByChecksum' -Exactly 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Test-FileMatchesArchiveEntryByChecksum' -ParameterFilter $testFileMatchesArchiveEntryByChecksumParameterFilter -Exactly 1 -Scope 'Context'
                 }
 
                 It 'Should remove the existing item at the desired path of the archive entry at the destination' {
@@ -5018,7 +4989,7 @@ Describe 'Archive Unit Tests' {
                         return $fileParameterCorrect -and $archiveEntryParameterCorrect -and $checksumParameterCorrect
                     }
                     
-                    Assert-MockCalled -CommandName 'Test-FileMatchesArchiveEntryByChecksum' -Exactly 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Test-FileMatchesArchiveEntryByChecksum' -ParameterFilter $testFileMatchesArchiveEntryByChecksumParameterFilter -Exactly 1 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove the existing item at the desired path of the archive entry at the destination' {
@@ -6403,7 +6374,7 @@ Describe 'Archive Unit Tests' {
                         return $fileParameterCorrect -and $archiveEntryParameterCorrect -and $checksumParameterCorrect
                     }
                     
-                    Assert-MockCalled -CommandName 'Test-FileMatchesArchiveEntryByChecksum' -Exactly 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Test-FileMatchesArchiveEntryByChecksum' -ParameterFilter $testFileMatchesArchiveEntryByChecksumParameterFilter -Exactly 1 -Scope 'Context'
                 }
 
                 It 'Should not attempt to remove an existing file at the desired path of the archive entry at the destination' {
@@ -6510,7 +6481,7 @@ Describe 'Archive Unit Tests' {
                         return $fileParameterCorrect -and $archiveEntryParameterCorrect -and $checksumParameterCorrect
                     }
                     
-                    Assert-MockCalled -CommandName 'Test-FileMatchesArchiveEntryByChecksum' -Exactly 1 -Scope 'Context'
+                    Assert-MockCalled -CommandName 'Test-FileMatchesArchiveEntryByChecksum' -ParameterFilter $testFileMatchesArchiveEntryByChecksumParameterFilter -Exactly 1 -Scope 'Context'
                 }
 
                 It 'Should remove the file at the desired path of the archive entry at the destination' {


### PR DESCRIPTION
I have removed the Get-Date function from the resource entirely.
That function was what was causing a problem with dates from cultures that were not en-US since it always defaults to en-US dates rather than the appropriately cultured date.
This should fix #61 though I can't personally reproduce the culture problem to confirm that the issue is fixed so I will leave the issue open until it is confirmed fixed.

I also fixed an issue with the Archive resource on Windows 10 in which it hadn't properly loaded the Get-FileHash function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/74)
<!-- Reviewable:end -->
