### PR TITLE
Update Test-IsNanoServer to return false if Get-ComputerInfo fails

### DIFF
--- a/DscResources/CommonResourceHelper.psm1
+++ b/DscResources/CommonResourceHelper.psm1
@@ -12,13 +12,16 @@ function Test-IsNanoServer
     
     if (Test-CommandExists -Name 'Get-ComputerInfo')
     {
-        $computerInfo = Get-ComputerInfo
+        $computerInfo = Get-ComputerInfo -ErrorAction 'SilentlyContinue'
 
-        $computerIsServer = 'Server' -ieq $computerInfo.OsProductType
-
-        if ($computerIsServer)
+        if ($null -ne $computerInfo)
         {
-            $isNanoServer = 'NanoServer' -ieq $computerInfo.OsServerLevel
+            $computerIsServer = 'Server' -ieq $computerInfo.OsProductType
+
+            if ($computerIsServer)
+            {
+                $isNanoServer = 'NanoServer' -ieq $computerInfo.OsServerLevel
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ The following parameters will be the same for each process in the set:
     * Added handling of directory archive entries that end with a foward slash
 * WindowsProcess:
     * Fix unreliable tests
+* Updated Test-IsNanoServer to return false if Get-ComputerInfo fails
 
 ### 2.7.0.0
 

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'CommonResourceHelper Unit Tests' {
             Mock -CommandName 'Test-CommandExists' -MockWith { return $true }
             Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoNanoServer }
 
-            Context 'Get-ComputerInfo command exists' {
+            Context 'Get-ComputerInfo command exists and succeeds' {
                 Context 'Computer OS type is Server and OS server level is NanoServer' {
                     It 'Should not throw' {
                         { $null = Test-IsNanoServer } | Should Not Throw
@@ -100,6 +100,30 @@ Describe 'CommonResourceHelper Unit Tests' {
                     It 'Should return false' {
                         Test-IsNanoServer | Should Be $false
                     }
+                }
+            }
+
+            Context 'Get-ComputerInfo command exists but throws an error and returns null' {
+                Mock -CommandName 'Get-ComputerInfo' -MockWith { return $null }
+
+                It 'Should not throw' {
+                    { $null = Test-IsNanoServer } | Should Not Throw
+                }
+
+                It 'Should test if the Get-ComputerInfo command exists' {
+                    $testCommandExistsParameterFilter = {
+                        return $Name -eq 'Get-ComputerInfo'
+                    }
+
+                    Assert-MockCalled -CommandName 'Test-CommandExists' -ParameterFilter $testCommandExistsParameterFilter -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should retrieve the computer info' {
+                    Assert-MockCalled -CommandName 'Get-ComputerInfo' -Exactly 1 -Scope 'Context'
+                }
+
+                It 'Should return false' {
+                    Test-IsNanoServer | Should Be $false
                 }
             }
 


### PR DESCRIPTION
Test-IsNanoServer will now return false if Get-ComputerInfo fails rather than failing itself.
This should fix #65

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/75)
<!-- Reviewable:end -->
