### PR TITLE
Registry: Fixed bug when registry name contains drive

### DIFF
--- a/DscResources/MSFT_RegistryResource/MSFT_RegistryResource.psm1
+++ b/DscResources/MSFT_RegistryResource/MSFT_RegistryResource.psm1
@@ -523,6 +523,10 @@ function Test-TargetResource
 
     .PARAMETER Path
         The path to retrieve the root of.
+
+    .NOTES
+        Don't use Split-Path here as it will pick up extra drives in the registry key name instead of the actual path root.
+        ex: 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\TestKey2\C:/Program Files (x86)/'
 #>
 function Get-PathRoot
 {
@@ -536,13 +540,12 @@ function Get-PathRoot
         $Path
     )
 
-    $pathParent = Split-Path -Path $Path -Parent
     $pathRoot = $Path
+    $firstIndexOfBackslash = $Path.IndexOf('\')
 
-    while (-not [String]::IsNullOrEmpty($pathParent))
+    if ($firstIndexOfBackslash -ge 0)
     {
-        $pathRoot = Split-Path -Path $pathParent -Leaf
-        $pathParent = Split-Path -Path $pathParent -Parent
+        $pathRoot = $Path.Substring(0, $firstIndexOfBackslash)
     }
 
     return $pathRoot

--- a/README.md
+++ b/README.md
@@ -583,6 +583,8 @@ The following parameters will be the same for each process in the set:
 * WindowsProcess:
     * Fix unreliable tests
 * Updated Test-IsNanoServer to return false if Get-ComputerInfo fails
+* Registry:
+    * Fixed bug when using the full registry drive name (e.g. HKEY\_LOCAL\_MACHINE) and using a key name that includes a drive with forward slashes (e.g. C:/)
 
 ### 2.7.0.0
 

--- a/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
@@ -37,6 +37,7 @@ try
 
             $script:registryKeyValueTypes = @( 'String', 'Binary', 'DWord', 'QWord', 'MultiString', 'ExpandString' )
             $script:testRegistryKeyPath = 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\TestKey2'
+            $script:testRegistryKeyWithDrivePath = 'HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\TestKey2\C:/Program Files (x86)/'
 
             # Force is specified as true for both of these configurations
             $script:confgurationFilePathKeyAndNameOnly = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_RegistryResource_KeyAndNameOnly.config.ps1'
@@ -243,6 +244,44 @@ try
 
             It 'Should have set the registry key value to the specified Binary value' {
                 Compare-Object -ReferenceObject $expectedRegistryKeyValue -DifferenceObject $registryKeyValue.'(default)' | Should Be $null
+            }
+
+            It 'Should return true from Test-TargetResource with the same parameters' {
+                MSFT_RegistryResource\Test-TargetResource @registryParameters | Should Be $true
+            }
+        }
+
+        Context 'Set a registry key value with a drive in the key name' {
+            $configurationName = 'SetRegistryKeyValueString'
+
+            $registryParameters = @{
+                Key = $script:testRegistryKeyWithDrivePath
+                Ensure = 'Present'
+                ValueName = 'TestValue'
+                ValueType = 'String'
+                ValueData = '0'
+            }
+
+            It 'Should compile and run configuration' {
+                { 
+                    . $script:confgurationFilePathWithDataAndType -ConfigurationName $configurationName
+                    & $configurationName -OutputPath $TestDrive @registryParameters
+                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                } | Should Not Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
+            }
+
+            $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
+
+            It 'Should have created the registry key value' {
+                $registryKeyValue | Should Not Be $null
+            }
+
+            It 'Should have set the registry key value to the specified value' {
+                $registryKeyValue.($registryParameters.ValueName) | Should Be $registryParameters.ValueData
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {

--- a/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_RegistryResource.EndToEnd.Tests.ps1
@@ -274,14 +274,15 @@ try
                 { Get-DscConfiguration -ErrorAction 'Stop' } | Should Not Throw
             }
 
-            $registryKeyValue = Get-ItemProperty -Path $registryParameters.Key -Name $registryParameters.ValueName -ErrorAction 'SilentlyContinue'
+            $parentRegistryKey = Get-Item -Path 'HKLM:'
+            $registryKey = $parentRegistryKey.OpenSubKey('SYSTEM\CurrentControlSet\Control\Session Manager\Environment\TestKey2\C:/Program Files (x86)/', $false)
 
             It 'Should have created the registry key value' {
-                $registryKeyValue | Should Not Be $null
+                $registryKey | Should Not Be $null
             }
 
             It 'Should have set the registry key value to the specified value' {
-                $registryKeyValue.($registryParameters.ValueName) | Should Be $registryParameters.ValueData
+                $registryKey.GetValue($registryParameters.ValueName) | Should Be $registryParameters.ValueData
             }
 
             It 'Should return true from Test-TargetResource with the same parameters' {

--- a/Tests/Unit/MSFT_RegistryResource.Tests.ps1
+++ b/Tests/Unit/MSFT_RegistryResource.Tests.ps1
@@ -2587,7 +2587,7 @@ try
 
                 $getPathRootResult = Get-PathRoot @getPathRootParameters
 
-                It 'Should return given path' {
+                It 'Should return the given path' {
                     $getPathRootResult | Should Be $getPathRootParameters.Path
                 }
             }


### PR DESCRIPTION
I fixed a bug when using the full registry drive name (e.g. HKEY\_LOCAL\_MACHINE) and using a key name that includes a drive with forward slashes (e.g. C:/). (Fixes #68)

I also added an integration test for this case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/78)
<!-- Reviewable:end -->
