### PR TITLE
Fix to issue 116: Test-TargetResource throws System.InvalidOperationException when defined user lacks permissions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 #---------------------------------#
 #      environment configuration  #
 #---------------------------------#
-version: 2.4.{build}.0
+version: 2.9.{build}.0
 os: Visual Studio 2015
 install:
     - git clone https://github.com/PowerShell/DscResource.Tests


### PR DESCRIPTION
Fix to issue 116: Test-TargetResource throws System.InvalidOperationException when defined user lacks permissions
- Observations
  - Used the User DSCR to create a local user 'NoGroupTest' on the target node, when the example configuration is initially applied there are no errors in the console or Microsoft-Windows-DSC/Operational.
  - However once the LCM auto applies the current config (or a user runs: Start-DscConfiguration -UseExisting -Force -Wait) the LCM will report exceptions thrown by User: Test-TargetResource
  - Traced the exception down to the helper function MSFT_UserResource\Test-UserPasswordOnFullSku specifically the call to ValidateCredentials method of the class System.DirectoryServices.AccountManagement.PrincipalContext
  - Tried work arounds like adding the test user to the local admin group but that made no difference
  - Did some research and found the above method has some [known issues](https://stackoverflow.com/questions/15622304/error-when-using-principalcontext-validatecredentials-to-authenticate-against-a) and the recommedation is call the WIN32 function LogonUser in advapi32.dll
  - This pull request contains the modification to the helper function MSFT_UserResource\Test-UserPasswordOnFullSku to use LogonUser
  - The above change appears to work for users even if they are not a member of any local group