### PR TITLE
replace PSDesResources with PSDscResources in URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,8 @@ The following parameters will be the same for each process in the set:
 
 ### Unreleased
 
+* Fixed URLs in the Examples sections in the WindowsPackage, WindowsProcess and ProcessSet resources.
+
 ### 2.9.0.0
 
 * Added Description and Parameter description for composite resources

--- a/README.md
+++ b/README.md
@@ -501,7 +501,7 @@ None
 
 #### Examples
 
-* [Install a cab file with the given name from the given path](https://github.com/PowerShell/PSDesResources/blob/master/Examples/Sample_WindowsPackageCab.ps1)
+* [Install a cab file with the given name from the given path](https://github.com/PowerShell/PSDscResources/blob/master/Examples/Sample_WindowsPackageCab.ps1)
 
 ### WindowsProcess
 
@@ -533,10 +533,10 @@ None
 
 #### Examples
 
-* [Start a process](https://github.com/PowerShell/PSDesResources/blob/master/Examples/Sample_WindowsProcess_Start.ps1)
-* [Stop a process](https://github.com/PowerShell/PSDesResources/blob/master/Examples/Sample_WindowsProcess_Stop.ps1)
-* [Start a process under a user](https://github.com/PowerShell/PSDesResources/blob/master/Examples/Sample_WindowsProcess_StartUnderUser.ps1)
-* [Stop a process under a user](https://github.com/PowerShell/PSDesResources/blob/master/Examples/Sample_WindowsProcess_StopUnderUser.ps1)
+* [Start a process](https://github.com/PowerShell/PSDscResources/blob/master/Examples/Sample_WindowsProcess_Start.ps1)
+* [Stop a process](https://github.com/PowerShell/PSDscResources/blob/master/Examples/Sample_WindowsProcess_Stop.ps1)
+* [Start a process under a user](https://github.com/PowerShell/PSDscResources/blob/master/Examples/Sample_WindowsProcess_StartUnderUser.ps1)
+* [Stop a process under a user](https://github.com/PowerShell/PSDscResources/blob/master/Examples/Sample_WindowsProcess_StopUnderUser.ps1)
 
 ### ProcessSet
 
@@ -570,8 +570,8 @@ The following parameters will be the same for each process in the set:
 
 #### Examples
 
-* [Start multiple processes](https://github.com/PowerShell/PSDesResources/blob/master/Examples/Sample_ProcessSet_Start.ps1)
-* [Stop multiple processes](https://github.com/PowerShell/PSDesResources/blob/master/Examples/Sample_ProcessSet_Stop.ps1)
+* [Start multiple processes](https://github.com/PowerShell/PSDscResources/blob/master/Examples/Sample_ProcessSet_Start.ps1)
+* [Stop multiple processes](https://github.com/PowerShell/PSDscResources/blob/master/Examples/Sample_ProcessSet_Stop.ps1)
 
 ## Versions
 


### PR DESCRIPTION
Fixed a typo where /PSDesResources/ was used instead of /PSDscResources/ in some URL's.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/125)
<!-- Reviewable:end -->
