### PR TITLE
Update CommonResourceHelper and ResourceHelper tests to Pester 4 standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,10 @@ The following parameters will be the same for each process in the set:
 
 ### Unreleased
 
+* Update `CommonResourceHelper` unit tests to meet Pester 4.0.0
+  standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
+* Update `ResourceHelper` unit tests to meet Pester 4.0.0
+  standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
 * Ported fixes from [xPSDesiredStateConfiguration](https://github.com/PowerShell/xPSDesiredStateConfiguration):
   * xArchive
     * Fix end-to-end tests.

--- a/Tests/Unit/CommonResourceHelper.Tests.ps1
+++ b/Tests/Unit/CommonResourceHelper.Tests.ps1
@@ -34,7 +34,7 @@ Describe 'CommonResourceHelper Unit Tests' {
             Context 'Get-ComputerInfo command exists and succeeds' {
                 Context 'Computer OS type is Server and OS server level is NanoServer' {
                     It 'Should not throw' {
-                        { $null = Test-IsNanoServer } | Should Not Throw
+                        { $null = Test-IsNanoServer } | Should -Not -Throw
                     }
 
                     It 'Should test if the Get-ComputerInfo command exists' {
@@ -50,7 +50,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     }
 
                     It 'Should return true' {
-                        Test-IsNanoServer | Should Be $true
+                        Test-IsNanoServer | Should -Be $true
                     }
                 }
 
@@ -58,7 +58,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoServerNotNano }
                     
                     It 'Should not throw' {
-                        { $null = Test-IsNanoServer } | Should Not Throw
+                        { $null = Test-IsNanoServer } | Should -Not -Throw
                     }
 
                     It 'Should test if the Get-ComputerInfo command exists' {
@@ -74,7 +74,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     }
 
                     It 'Should return false' {
-                        Test-IsNanoServer | Should Be $false
+                        Test-IsNanoServer | Should -Be $false
                     }
                 }
 
@@ -82,7 +82,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     Mock -CommandName 'Get-ComputerInfo' -MockWith { return $testComputerInfoNotServer }
 
                     It 'Should not throw' {
-                        { $null = Test-IsNanoServer } | Should Not Throw
+                        { $null = Test-IsNanoServer } | Should -Not -Throw
                     }
 
                     It 'Should test if the Get-ComputerInfo command exists' {
@@ -98,7 +98,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                     }
 
                     It 'Should return false' {
-                        Test-IsNanoServer | Should Be $false
+                        Test-IsNanoServer | Should -Be $false
                     }
                 }
             }
@@ -107,7 +107,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 Mock -CommandName 'Get-ComputerInfo' -MockWith { return $null }
 
                 It 'Should not throw' {
-                    { $null = Test-IsNanoServer } | Should Not Throw
+                    { $null = Test-IsNanoServer } | Should -Not -Throw
                 }
 
                 It 'Should test if the Get-ComputerInfo command exists' {
@@ -123,7 +123,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
 
                 It 'Should return false' {
-                    Test-IsNanoServer | Should Be $false
+                    Test-IsNanoServer | Should -Be $false
                 }
             }
 
@@ -131,7 +131,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 Mock -CommandName 'Test-CommandExists' -MockWith { return $false }
 
                 It 'Should not throw' {
-                    { $null = Test-IsNanoServer } | Should Not Throw
+                    { $null = Test-IsNanoServer } | Should -Not -Throw
                 }
 
                 It 'Should test if the Get-ComputerInfo command exists' {
@@ -147,7 +147,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
 
                 It 'Should return false' {
-                    Test-IsNanoServer | Should Be $false
+                    Test-IsNanoServer | Should -Be $false
                 }
             }
         }
@@ -159,7 +159,7 @@ Describe 'CommonResourceHelper Unit Tests' {
 
             Context 'Get-Command returns the command' {
                 It 'Should not throw' {
-                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                    { $null = Test-CommandExists -Name $testCommandName } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the command with the specified name' {
@@ -171,7 +171,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
 
                 It 'Should return true' {
-                    Test-CommandExists -Name $testCommandName | Should Be $true
+                    Test-CommandExists -Name $testCommandName | Should -Be $true
                 }
             }
 
@@ -179,7 +179,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 Mock -CommandName 'Get-Command' -MockWith { return $null }
 
                 It 'Should not throw' {
-                    { $null = Test-CommandExists -Name $testCommandName } | Should Not Throw
+                    { $null = Test-CommandExists -Name $testCommandName } | Should -Not -Throw
                 }
 
                 It 'Should retrieve the command with the specified name' {
@@ -191,7 +191,7 @@ Describe 'CommonResourceHelper Unit Tests' {
                 }
 
                 It 'Should return false' {
-                    Test-CommandExists -Name $testCommandName | Should Be $false
+                    Test-CommandExists -Name $testCommandName | Should -Be $false
                 }
             }
         }

--- a/Tests/Unit/ResourceSetHelper.Tests.ps1
+++ b/Tests/Unit/ResourceSetHelper.Tests.ps1
@@ -21,7 +21,7 @@ InModuleScope 'ResourceSetHelper' {
             $keyParameterName = 'Name'
 
             $commonParameterString = New-ResourceSetCommonParameterString -KeyParameterName $keyParameterName -Parameters $parameters
-            $commonParameterString | Should Be "CommonStringParameter1 = `"CommonParameter1`"`r`n"
+            $commonParameterString | Should -Be "CommonStringParameter1 = `"CommonParameter1`"`r`n"
         }
 
         It 'Should return string containing one variable reference for one credential common parameter' {
@@ -36,7 +36,7 @@ InModuleScope 'ResourceSetHelper' {
             $keyParameterName = 'Name'
 
             $commonParameterString = New-ResourceSetCommonParameterString -KeyParameterName $keyParameterName -Parameters $parameters
-            $commonParameterString | Should Be "CommonCredentialParameter1 = `$CommonCredentialParameter1`r`n"
+            $commonParameterString | Should -Be "CommonCredentialParameter1 = `$CommonCredentialParameter1`r`n"
         }
 
         It 'Should return string containing all parameters for two string common parameters and two int common parameters' {
@@ -51,10 +51,10 @@ InModuleScope 'ResourceSetHelper' {
             $keyParameterName = 'Name'
 
             $commonParameterString = New-ResourceSetCommonParameterString -KeyParameterName $keyParameterName -Parameters $parameters
-            $commonParameterString.Contains("CommonStringParameter1 = `"CommonParameter1`"`r`n") | Should Be $true
-            $commonParameterString.Contains("CommonStringParameter2 = `"CommonParameter2`"`r`n") | Should Be $true
-            $commonParameterString.Contains("CommonIntParameter1 = `$CommonIntParameter1`r`n") | Should Be $true
-            $commonParameterString.Contains("CommonIntParameter2 = `$CommonIntParameter2`r`n") | Should Be $true
+            $commonParameterString.Contains("CommonStringParameter1 = `"CommonParameter1`"`r`n") | Should -Be $true
+            $commonParameterString.Contains("CommonStringParameter2 = `"CommonParameter2`"`r`n") | Should -Be $true
+            $commonParameterString.Contains("CommonIntParameter1 = `$CommonIntParameter1`r`n") | Should -Be $true
+            $commonParameterString.Contains("CommonIntParameter2 = `$CommonIntParameter2`r`n") | Should -Be $true
         }
     }
 
@@ -69,7 +69,7 @@ InModuleScope 'ResourceSetHelper' {
 
         It 'Should return string with module import and one resource for one key value' {
             $resourceString = New-ResourceSetConfigurationString @newResourceSetConfigurationStringParams
-            $resourceString | Should Be ("Import-DscResource -Name ResourceName -ModuleName ModuleName`r`n" + `
+            $resourceString | Should -Be ("Import-DscResource -Name ResourceName -ModuleName ModuleName`r`n" + `
                 "ResourceName Resource0`r`n{`r`nName = `"KeyValue1`"`r`n$($newResourceSetConfigurationStringParams['CommonParameterString'])}`r`n")
         }
 
@@ -77,7 +77,7 @@ InModuleScope 'ResourceSetHelper' {
 
         It 'Should return string with module import and two resources for two key values' {
             $resourceString = New-ResourceSetConfigurationString @newResourceSetConfigurationStringParams
-            $resourceString | Should Be ("Import-DscResource -Name ResourceName -ModuleName ModuleName`r`n" + `
+            $resourceString | Should -Be ("Import-DscResource -Name ResourceName -ModuleName ModuleName`r`n" + `
                 "ResourceName Resource0`r`n{`r`nName = `"KeyValue1`"`r`n$($newResourceSetConfigurationStringParams['CommonParameterString'])}`r`n" + `
                 "ResourceName Resource1`r`n{`r`nName = `"KeyValue2`"`r`n$($newResourceSetConfigurationStringParams['CommonParameterString'])}`r`n")
         }
@@ -104,11 +104,11 @@ InModuleScope 'ResourceSetHelper' {
         $newResourceSetConfigurationScriptBlock = New-ResourceSetConfigurationScriptBlock @newResourceSetConfigurationParams
 
         It 'Should return a ScriptBlock' {
-            $newResourceSetConfigurationScriptBlock -is [ScriptBlock] | Should Be $true
+            $newResourceSetConfigurationScriptBlock -is [ScriptBlock] | Should -Be $true
         }
 
         It 'Should return ScriptBlock of string returned from New-ResourceSetConfigurationString' {
-            $newResourceSetConfigurationScriptBlock | Should Match ([ScriptBlock]::Create($configurationString))
+            $newResourceSetConfigurationScriptBlock | Should -Match ([ScriptBlock]::Create($configurationString))
         }
 
         It 'Should call New-ResourceSetConfigurationString with the correct ModuleName' {


### PR DESCRIPTION
#### Pull Request (PR) description

This PR:
* Update `CommonResourceHelper` unit tests to meet Pester 4.0.0
  standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
* Update `ResourceHelper` unit tests to meet Pester 4.0.0
  standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).

#### This Pull Request (PR) fixes the following issues

- Does not fix any issues but contributes to #129

#### Task list

- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

@johlju would you mind reviewing when you get a moment. Should be straight forward.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xpsdesiredstateconfiguration/475)
<!-- Reviewable:end -->
