### PR TITLE
Update Group and GroupSet tests to meet Pester 4 standards

### DIFF
--- a/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
+++ b/DscResources/MSFT_GroupResource/MSFT_GroupResource.psm1
@@ -127,7 +127,7 @@ function Get-TargetResource
 
         To ensure that the group does exist, set this property to present.
         To ensure that the group does not exist, set this property to Absent.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -138,10 +138,10 @@ function Get-TargetResource
 
         This property will replace all the current group members with the specified members.
 
-        Members should be specified as strings in the format of their domain qualified name 
+        Members should be specified as strings in the format of their domain qualified name
         (domain\username), their UPN (username@domainname), their distinguished name (CN=username,DC=...),
-        or their username (for local machine accounts).  
-        
+        or their username (for local machine accounts).
+
         Using either the MembersToExclude or MembersToInclude properties in the same configuration
         as this property will generate an error.
 
@@ -150,7 +150,7 @@ function Get-TargetResource
 
         This property will only add members to a group.
 
-        Members should be specified as strings in the format of their domain qualified name 
+        Members should be specified as strings in the format of their domain qualified name
         (domain\username), their UPN (username@domainname), their distinguished name (CN=username,DC=...),
         or their username (for local machine accounts).
 
@@ -161,7 +161,7 @@ function Get-TargetResource
 
         This property will only remove members from a group.
 
-        Members should be specified as strings in the format of their domain qualified name 
+        Members should be specified as strings in the format of their domain qualified name
         (domain\username), their UPN (username@domainname), their distinguished name (CN=username,DC=...),
         or their username (for local machine accounts).
 
@@ -244,10 +244,10 @@ function Set-TargetResource
 
     .PARAMETER Members
         The list of members the group should have.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
-        a unqualified (username) for local machine accounts.  
+        a unqualified (username) for local machine accounts.
 
         If you set this property in a configuration, do not use either the MembersToExclude or
         MembersToInclude property. Doing so will generate an error.
@@ -255,9 +255,9 @@ function Set-TargetResource
     .PARAMETER MembersToInclude
         A list of members that should be in the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
-        a unqualified (username) for local machine accounts.  
+        a unqualified (username) for local machine accounts.
 
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
@@ -265,7 +265,7 @@ function Set-TargetResource
     .PARAMETER MembersToExclude
         A list of members that should not be in the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -454,10 +454,10 @@ function Get-TargetResourceOnNanoServer
 
     .PARAMETER Ensure
         Indicates if the group should exist or not.
-        
+
         Set this property to Present to ensure that the group exists.
         Set this property to Absent to ensure that the group does not exist.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -465,31 +465,31 @@ function Get-TargetResourceOnNanoServer
 
     .PARAMETER Members
         Use this property to replace the current group membership with the specified members.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         an unqualified (username) for local machine accounts.
-        
-        If you set this property in a configuration, do not use either the MembersToExclude or 
+
+        If you set this property in a configuration, do not use either the MembersToExclude or
         MembersToInclude property. Doing so will generate an error.
 
     .PARAMETER MembersToInclude
         Use this property to add members to the existing membership of the group.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
-        a unqualified (username) for local machine accounts. 
-        
+        a unqualified (username) for local machine accounts.
+
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
 
     .PARAMETER MembersToExclude
         Use this property to remove members from the existing membership of the group.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
-        a unqualified (username) for local machine accounts. 
-        
+        a unqualified (username) for local machine accounts.
+
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
 
@@ -806,10 +806,10 @@ function Set-TargetResourceOnFullSKU
 
     .PARAMETER Ensure
         Indicates if the group should exist or not.
-        
+
         Set this property to Present to ensure that the group exists.
         Set this property to Absent to ensure that the group does not exist.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -817,31 +817,31 @@ function Set-TargetResourceOnFullSKU
 
     .PARAMETER Members
         Use this property to replace the current group membership with the specified members.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
-        
-        If you set this property in a configuration, do not use either the MembersToExclude or 
+
+        If you set this property in a configuration, do not use either the MembersToExclude or
         MembersToInclude property. Doing so will generate an error.
 
     .PARAMETER MembersToInclude
         Use this property to add members to the existing membership of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
-        
+
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
 
     .PARAMETER MembersToExclude
         Use this property to remove members from the existing membership of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
-        
+
         If you set this property in a configuration, do not use the Members property.
         Doing so will generate an error.
 
@@ -923,7 +923,7 @@ function Set-TargetResourceOnNanoServer
             }
 
             # Set the group properties.
-            if ($PSBoundParameters.ContainsKey('Description') -and 
+            if ($PSBoundParameters.ContainsKey('Description') -and
                 ((-not $groupOriginallyExists) -or ($Description -ne $group.Description)))
             {
                 Set-LocalGroup -Name $GroupName -Description $Description
@@ -1036,10 +1036,10 @@ function Set-TargetResourceOnNanoServer
 
     .PARAMETER Ensure
         Indicates if the group should exist or not.
-        
+
         Set this property to Present to ensure that the group exists.
         Set this property to Absent to ensure that the group does not exist.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -1048,8 +1048,8 @@ function Set-TargetResourceOnNanoServer
     .PARAMETER Members
         Use this property to test if the existing membership of the group matches
         the list provided.
-        
-        The value of this property is an array of strings of the formats domain qualified name 
+
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1058,9 +1058,9 @@ function Set-TargetResourceOnNanoServer
 
     .PARAMETER MembersToInclude
         Use this property to test if members need to be added to the existing membership
-        of the group. 
+        of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1071,7 +1071,7 @@ function Set-TargetResourceOnNanoServer
         Use this property to test if members need to removed from the existing membership
         of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1297,10 +1297,10 @@ function Test-TargetResourceOnFullSKU
 
     .PARAMETER Ensure
         Indicates if the group should exist or not.
-        
+
         Set this property to Present to ensure that the group exists.
         Set this property to Absent to ensure that the group does not exist.
-        
+
         The default value is Present.
 
     .PARAMETER Description
@@ -1310,7 +1310,7 @@ function Test-TargetResourceOnFullSKU
         Use this property to test if the existing membership of the group matches
         the list provided.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1321,7 +1321,7 @@ function Test-TargetResourceOnFullSKU
         Use this property to test if members need to be added to the existing membership
         of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -1332,7 +1332,7 @@ function Test-TargetResourceOnFullSKU
         Use this property to test if members need to removed from the existing membership
         of the group.
 
-        The value of this property is an array of strings of the formats domain qualified name 
+        The value of this property is an array of strings of the formats domain qualified name
         (domain\username), UPN (username@domainname), distinguished name (CN=username,DC=...) and/or
         a unqualified (username) for local machine accounts.
 
@@ -2117,7 +2117,7 @@ function Get-PrincipalContext
         }
 
         $principalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' `
-            -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Domain, $Scope, 
+            -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Domain, $Scope,
                 $principalContextName, $Credential.GetNetworkCredential().Password )
 
         # Cache the PrincipalContext for this scope for subsequent calls.
@@ -2341,7 +2341,7 @@ function Find-Principal
     {
         return [System.DirectoryServices.AccountManagement.Principal]::FindByIdentity($PrincipalContext, $IdentityValue)
     }
-    
+
 }
 
 <#
@@ -2435,7 +2435,7 @@ function Clear-GroupMembers
         [System.DirectoryServices.AccountManagement.GroupPrincipal]
         $Group
     )
-    
+
     $Group.Members.Clear()
 }
 
@@ -2517,7 +2517,7 @@ function Remove-Group
         [System.DirectoryServices.AccountManagement.GroupPrincipal]
         $Group
     )
-    
+
     $Group.Delete()
 }
 

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ The following parameters will be the same for each process in the set:
 * Update `ResourceHelper` unit tests to meet Pester 4.0.0
   standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
 * Ported fixes from [xPSDesiredStateConfiguration](https://github.com/PowerShell/xPSDesiredStateConfiguration):
-  * xArchive:
+  * xArchive
     * Fix end-to-end tests.
     * Update integration tests to meet Pester 4.0.0 standards.
     * Update end-to-end tests to meet Pester 4.0.0 standards.
@@ -609,11 +609,11 @@ The following parameters will be the same for each process in the set:
   installed in AppVeyor images ([Issue #128](https://github.com/PowerShell/PSDscResources/issues/128)).
 * Removed .vscode from .gitignore so that Visual Studio code environment
   settings can be committed.
-* Environment:
+* Environment
   * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
-* Group:
+* Group
   * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
-* GroupSet:
+* GroupSet
   * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
 
 ### 2.9.0.0
@@ -622,13 +622,13 @@ The following parameters will be the same for each process in the set:
 
 ### 2.8.0.0
 
-* Archive:
+* Archive
   * Added handling of directory archive entries that end with a foward slash
   * Removed formatting of LastWriteTime timestamp and updated comparison of timestamps to handle dates in different formats
-* WindowsProcess:
+* WindowsProcess
   * Fix unreliable tests
 * Updated Test-IsNanoServer to return false if Get-ComputerInfo fails
-* Registry:
+* Registry
   * Fixed bug when using the full registry drive name (e.g. HKEY\_LOCAL\_MACHINE) and using a key name that includes a drive with forward slashes (e.g. C:/)
 
 ### 2.7.0.0
@@ -639,7 +639,7 @@ The following parameters will be the same for each process in the set:
 
 ### 2.6.0.0
 
-* Archive:
+* Archive
   * Fixed a minor bug in the unit tests where sometimes the incorrect DateTime format was used.
 * Added MsiPackage
 

--- a/README.md
+++ b/README.md
@@ -613,6 +613,9 @@ The following parameters will be the same for each process in the set:
   * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
 * Group
   * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
+  * Fix unit tests to run on Nano Server.
+  * Refactored unit tests to enclude Context fixtures and change functions
+    to Describe fixtures.
 * GroupSet
   * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
 

--- a/README.md
+++ b/README.md
@@ -584,7 +584,7 @@ The following parameters will be the same for each process in the set:
 * Update `ResourceHelper` unit tests to meet Pester 4.0.0
   standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
 * Ported fixes from [xPSDesiredStateConfiguration](https://github.com/PowerShell/xPSDesiredStateConfiguration):
-  * xArchive
+  * xArchive:
     * Fix end-to-end tests.
     * Update integration tests to meet Pester 4.0.0 standards.
     * Update end-to-end tests to meet Pester 4.0.0 standards.
@@ -609,7 +609,11 @@ The following parameters will be the same for each process in the set:
   installed in AppVeyor images ([Issue #128](https://github.com/PowerShell/PSDscResources/issues/128)).
 * Removed .vscode from .gitignore so that Visual Studio code environment
   settings can be committed.
-* Environment
+* Environment:
+  * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
+* Group:
+  * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
+* GroupSet:
   * Update tests to meet Pester 4.0.0 standards ([issue #129](https://github.com/PowerShell/PSDscResources/issues/129)).
 
 ### 2.9.0.0

--- a/Tests/Integration/GroupSet.Integration.Tests.ps1
+++ b/Tests/Integration/GroupSet.Integration.Tests.ps1
@@ -15,7 +15,6 @@ $script:testFolderPath = Split-Path -Path $PSScriptRoot -Parent
 $script:testHelpersPath = Join-Path -Path $script:testFolderPath -ChildPath 'TestHelpers'
 Import-Module -Name (Join-Path -Path $script:testHelpersPath -ChildPath 'CommonTestHelper.psm1')
 
-
 $script:testEnvironment = Enter-DscResourceTestEnvironment `
     -DscResourceModuleName 'PSDscResources' `
     -DscResourceName 'GroupSet' `
@@ -66,19 +65,19 @@ try
                 Ensure = 'Present'
             }
 
-            Test-GroupExists -GroupName $testGroupName1 | Should Be $false
-            Test-GroupExists -GroupName $testGroupName2 | Should Be $false
+            Test-GroupExists -GroupName $testGroupName1 | Should -Be $false
+            Test-GroupExists -GroupName $testGroupName2 | Should -Be $false
 
             try
             {
-                { 
+                {
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName1 -Members @() | Should Be $true
-                Test-GroupExists -GroupName $testGroupName2 -Members @() | Should Be $true
+                Test-GroupExists -GroupName $testGroupName1 -Members @() | Should -Be $true
+                Test-GroupExists -GroupName $testGroupName2 -Members @() | Should -Be $true
             }
             finally
             {
@@ -106,17 +105,17 @@ try
                 MembersToInclude = $groupMembers
             }
 
-            Test-GroupExists -GroupName $testGroupName1 | Should Be $false
+            Test-GroupExists -GroupName $testGroupName1 | Should -Be $false
 
             try
             {
-                { 
+                {
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName1 -MembersToInclude $groupMembers | Should Be $true
+                Test-GroupExists -GroupName $testGroupName1 -MembersToInclude $groupMembers | Should -Be $true
             }
             finally
             {
@@ -141,19 +140,19 @@ try
                 MembersToInclude = $groupMembers
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
-            Test-GroupExists -GroupName $administratorsGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
+            Test-GroupExists -GroupName $administratorsGroupName | Should -Be $true
 
             try
             {
-                { 
+                {
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -MembersToInclude $groupMembers | Should Be $true
-                Test-GroupExists -GroupName $administratorsGroupName -MembersToInclude $groupMembers | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -MembersToInclude $groupMembers | Should -Be $true
+                Test-GroupExists -GroupName $administratorsGroupName -MembersToInclude $groupMembers | Should -Be $true
             }
             finally
             {
@@ -166,7 +165,7 @@ try
 
         It 'Should remove two members from a set of three groups' {
             $configurationName = 'RemoveTwoMembersFromThreeGroups'
-            
+
             $testGroupNames = @('TestGroupWithMembersToExclude1', 'TestGroupWithMembersToExclude2', 'TestGroupWithMembersToExclude3')
 
             $groupMembersToExclude = @( $testUsername2, $testUsername3 )
@@ -179,24 +178,24 @@ try
 
             foreach ($testGroupName in $testGroupNames)
             {
-                Test-GroupExists -GroupName $testGroupName | Should Be $false
+                Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
                 New-Group -GroupName $testGroupName -Members $testUsernames
 
-                Test-GroupExists -GroupName $testGroupName | Should Be $true
+                Test-GroupExists -GroupName $testGroupName | Should -Be $true
             }
 
             try
             {
-                { 
+                {
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 foreach ($testGroupName in $testGroupNames)
                 {
-                    Test-GroupExists -GroupName $testGroupName -MembersToExclude $groupMembersToExclude | Should Be $true
+                    Test-GroupExists -GroupName $testGroupName -MembersToExclude $groupMembersToExclude | Should -Be $true
                 }
             }
             finally
@@ -213,7 +212,7 @@ try
 
         It 'Should remove a set of groups' {
                 $configurationName = 'RemoveThreeGroups'
-            
+
             $testGroupNames = @('TestGroupRemove1', 'TestGroupRemove2', 'TestGroupRemove3')
 
             $groupSetParameters = @{
@@ -221,27 +220,26 @@ try
                 Ensure = 'Absent'
             }
 
-
             foreach ($testGroupName in $testGroupNames)
             {
-                Test-GroupExists -GroupName $testGroupName | Should Be $false
+                Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
                 New-Group -GroupName $testGroupName
 
-                Test-GroupExists -GroupName $testGroupName | Should Be $true
+                Test-GroupExists -GroupName $testGroupName | Should -Be $true
             }
 
             try
             {
-                { 
+                {
                     . $script:confgurationFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @groupSetParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
                 foreach ($testGroupName in $testGroupNames)
                 {
-                    Test-GroupExists -GroupName $testGroupName | Should Be $false
+                    Test-GroupExists -GroupName $testGroupName | Should -Be $false
                 }
             }
             finally

--- a/Tests/Integration/GroupSet.config.ps1
+++ b/Tests/Integration/GroupSet.config.ps1
@@ -1,7 +1,7 @@
 ﻿param
 (
     [Parameter(Mandatory = $true)]
-    [String]
+    [System.String]
     $ConfigurationName
 )
 
@@ -11,18 +11,21 @@ Configuration $ConfigurationName
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String[]]
+        [System.String[]]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Ensure = 'Present',
 
-        [String[]]
+        [Parameter()]
+        [System.String[]]
         $MembersToInclude = @(),
 
-        [String[]]
+        [Parameter()]
+        [System.String[]]
         $MembersToExclude = @()
     )
 

--- a/Tests/Integration/MSFT_GroupResource.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_GroupResource.Integration.Tests.ps1
@@ -29,7 +29,7 @@ try
             $script:confgurationNoMembersFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_GroupResource_NoMembers.config.ps1'
             $script:confgurationWithMembersFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_GroupResource_Members.config.ps1'
             $script:confgurationWithMembersToIncludeExcludeFilePath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_GroupResource_MembersToIncludeExclude.config.ps1'
-                                                                            
+
             # Fake users for testing
             $testUsername1 = 'TestUser1'
             $testUsername2 = 'TestUser2'
@@ -56,7 +56,7 @@ try
         It 'Should use Group from PSDscResources' {
             $groupResource = Get-DscResource -Name 'Group'
 
-            $groupResource | Should Not Be $null
+            $groupResource | Should -Not -Be $null
 
             if ($groupResource.Count -gt 1)
             {
@@ -64,7 +64,7 @@ try
                 $groupResource = $sortedGroupResrources | Select-Object -First 1
             }
 
-            $groupResource.ModuleName | Should Be 'PSDscResources'
+            $groupResource.ModuleName | Should -Be 'PSDscResources'
         }
 
         It 'Should create an empty group' {
@@ -76,17 +76,17 @@ try
                 GroupName = $testGroupName
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
             try
             {
-                { 
+                {
                     . $script:confgurationWithMembersFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -Members @() | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -Members @() | Should -Be $true
             }
             finally
             {
@@ -106,15 +106,15 @@ try
                 GroupName = $testGroupName
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
-            { 
+            {
                 . $script:confgurationNoMembersFilePath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @resourceParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
         }
 
         It 'Should add a member to the built-in Users group with MembersToInclude' {
@@ -127,15 +127,15 @@ try
                 MembersToInclude = $testUsername1
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
-            { 
+            {
                 . $script:confgurationWithMembersToIncludeExcludeFilePath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @resourceParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
+            } | Should -Not -Throw
 
-            Test-GroupExists -GroupName $testGroupName -MembersToInclude $testUsername1 | Should Be $true
+            Test-GroupExists -GroupName $testGroupName -MembersToInclude $testUsername1 | Should -Be $true
         }
 
         It 'Should create a group with two test users using Members' {
@@ -150,17 +150,17 @@ try
                 Members = $groupMembers
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
             try
             {
-                { 
+                {
                     . $script:confgurationWithMembersFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -Members $groupMembers | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -Members $groupMembers | Should -Be $true
             }
             finally
             {
@@ -183,21 +183,21 @@ try
                 MembersToInclude = $groupMembers
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
             New-Group -GroupName $testGroupName
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
             try
             {
-                { 
+                {
                     . $script:confgurationWithMembersToIncludeExcludeFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -MembersToInclude $groupMembers | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -MembersToInclude $groupMembers | Should -Be $true
             }
             finally
             {
@@ -220,21 +220,21 @@ try
                 MembersToExclude = $groupMembersToExclude
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
             New-Group -GroupName $testGroupName -Members $groupMembersToExclude
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
             try
             {
-                { 
+                {
                     . $script:confgurationWithMembersToIncludeExcludeFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName -MembersToExclude $groupMembersToExclude | Should Be $true
+                Test-GroupExists -GroupName $testGroupName -MembersToExclude $groupMembersToExclude | Should -Be $true
             }
             finally
             {
@@ -254,21 +254,21 @@ try
                 GroupName = $testGroupName
             }
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $false
+            Test-GroupExists -GroupName $testGroupName | Should -Be $false
 
             New-Group -GroupName $testGroupName
 
-            Test-GroupExists -GroupName $testGroupName | Should Be $true
+            Test-GroupExists -GroupName $testGroupName | Should -Be $true
 
             try
             {
-                { 
+                {
                     . $script:confgurationWithMembersFilePath -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @resourceParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                } | Should -Not -Throw
 
-                Test-GroupExists -GroupName $testGroupName | Should Be $false
+                Test-GroupExists -GroupName $testGroupName | Should -Be $false
             }
             finally
             {

--- a/Tests/Integration/MSFT_GroupResource_Members.config.ps1
+++ b/Tests/Integration/MSFT_GroupResource_Members.config.ps1
@@ -1,7 +1,7 @@
 ﻿param
 (
     [Parameter(Mandatory = $true)]
-    [String]
+    [System.String]
     $ConfigurationName
 )
 
@@ -11,15 +11,17 @@ Configuration $ConfigurationName
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Ensure = 'Present',
 
-        [String[]]
+        [Parameter()]
+        [System.String[]]
         $Members = @()
     )
 

--- a/Tests/Integration/MSFT_GroupResource_MembersToIncludeExclude.config.ps1
+++ b/Tests/Integration/MSFT_GroupResource_MembersToIncludeExclude.config.ps1
@@ -1,7 +1,7 @@
 ﻿param
 (
     [Parameter(Mandatory = $true)]
-    [String]
+    [System.String]
     $ConfigurationName
 )
 
@@ -11,18 +11,21 @@ Configuration $ConfigurationName
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Ensure = 'Present',
 
-        [String[]]
+        [Parameter()]
+        [System.String[]]
         $MembersToInclude = @(),
 
-        [String[]]
+        [Parameter()]
+        [System.String[]]
         $MembersToExclude = @()
     )
 

--- a/Tests/Integration/MSFT_GroupResource_NoMembers.config.ps1
+++ b/Tests/Integration/MSFT_GroupResource_NoMembers.config.ps1
@@ -1,7 +1,7 @@
 ﻿param
 (
     [Parameter(Mandatory = $true)]
-    [String]
+    [System.String]
     $ConfigurationName
 )
 
@@ -11,12 +11,13 @@ Configuration $ConfigurationName
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $GroupName,
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $Ensure = 'Present'
     )
 

--- a/Tests/Unit/MSFT_GroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_GroupResource.Tests.ps1
@@ -4,19 +4,26 @@ param ()
 $errorActionPreference = 'Stop'
 Set-StrictMode -Version 'Latest'
 
-$script:testFolderPath = Split-Path -Path $PSScriptRoot -Parent
-$script:testHelpersPath = Join-Path -Path $script:testFolderPath -ChildPath 'TestHelpers'
-Import-Module -Name (Join-Path -Path $script:testHelpersPath -ChildPath 'CommonTestHelper.psm1')
+Describe 'GroupResource Unit Tests' {
+    BeforeAll {
+        # Import CommonTestHelper
+        $testsFolderFilePath = Split-Path $PSScriptRoot -Parent
+        $testHelperFolderFilePath = Join-Path -Path $testsFolderFilePath -ChildPath 'TestHelpers'
+        $commonTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'CommonTestHelper.psm1'
+        Import-Module -Name $commonTestHelperFilePath
 
-$script:testEnvironment = Enter-DscResourceTestEnvironment `
-    -DscResourceModuleName 'PSDscResources' `
-    -DscResourceName 'MSFT_GroupResource' `
-    -TestType 'Unit'
+        $script:testEnvironment = Enter-DscResourceTestEnvironment `
+            -DscResourceModuleName 'PSDscResources' `
+            -DscResourceName 'MSFT_GroupResource' `
+            -TestType 'Unit'
+    }
 
-try
-{
+    AfterAll {
+        Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
+    }
+
     InModuleScope 'MSFT_GroupResource' {
-        Describe 'Group Unit Tests' {
+        Describe 'All GroupResource Functions' {
             BeforeAll {
                 $script:disposableObjects = @()
 
@@ -100,294 +107,362 @@ try
                 because they are wrapper functions for .NET class function calls.
             #>
 
-            Describe 'Get-TargetResource' {
+            Describe 'GroupResource\Get-TargetResource' -Tag 'Get' {
                 Mock -CommandName 'Assert-GroupNameValid' -MockWith { }
                 Mock -CommandName 'Test-IsNanoServer' -MockWith { return $false }
                 Mock -CommandName 'Get-TargetResourceOnFullSKU' -MockWith { return @{ TestResult = 'OnFullSKU' } }
                 Mock -CommandName 'Get-TargetResourceOnNanoServer' -MockWith { return @{ TestResult = 'OnNanoServer' } }
 
-                It 'Should call Assert-GroupNameValid with the given group name' {
-                    $null = Get-TargetResource -GroupName $script:testGroupName
-                    Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                Context 'When called with the given group name' {
+                    It 'Should call Assert-GroupNameValid' {
+                        $null = Get-TargetResource -GroupName $script:testGroupName
+
+                        Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                    }
                 }
 
-                It 'Should return output Get-TargetResourceOnFullSKU with all parameters when not on Nano Server' {
-                    $getTargetResourceResult = Get-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+                Context 'When called with all parameters when not on Nano Server' {
+                    It 'Should return output from Get-TargetResourceOnFullSKU' {
+                        $getTargetResourceResult = Get-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
 
-                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                    Assert-MockCalled -CommandName 'Get-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                    $getTargetResourceResult.TestResult | Should -Be 'OnFullSKU'
+                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                        Assert-MockCalled -CommandName 'Get-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                        $getTargetResourceResult.TestResult | Should -Be 'OnFullSKU'
+                    }
                 }
 
-                It 'Should call Get-TargetResourceOnNanoServer with all parameters when on Nano Server' {
-                    Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
+                Context 'When called with all parameters when on Nano Server' {
+                    It 'Should return output from Get-TargetResourceOnNanoServer' {
+                        Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
 
-                    $getTargetResourceResult = Get-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+                        $getTargetResourceResult = Get-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
 
-                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                    Assert-MockCalled -CommandName 'Get-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                    $getTargetResourceResult.TestResult | Should -Be 'OnNanoServer'
+                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                        Assert-MockCalled -CommandName 'Get-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                        $getTargetResourceResult.TestResult | Should -Be 'OnNanoServer'
+                    }
                 }
             }
 
-            Describe 'Set-TargetResource' {
+            Describe 'GroupResource\Set-TargetResource' -Tag 'Set' {
                 Mock -CommandName 'Assert-GroupNameValid' -MockWith { }
                 Mock -CommandName 'Test-IsNanoServer' -MockWith { return $false }
                 Mock -CommandName 'Set-TargetResourceOnFullSKU' -MockWith { }
                 Mock -CommandName 'Set-TargetResourceOnNanoServer' -MockWith { }
 
-                It 'Should call Assert-GroupNameValid with the given group name' {
-                    $null = Set-TargetResource -GroupName $script:testGroupName
-                    Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                Context 'When called with the given group name' {
+                    It 'Should call Assert-GroupNameValid' {
+                        $null = Set-TargetResource -GroupName $script:testGroupName
+                        Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                    }
                 }
 
-                It 'Should call Set-TargetResourceOnFullSKU with all parameters when not on Nano Server' {
-                    Set-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+                Context 'When called with all parameters when not on Nano Server' {
+                    It 'Should call Set-TargetResourceOnFullSKU' {
+                        Set-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
 
-                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                    Assert-MockCalled -CommandName 'Set-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                        Assert-MockCalled -CommandName 'Set-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                    }
                 }
 
-                It 'Should call Set-TargetResourceOnNanoServer with all parameters when on Nano Server' {
-                    Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
+                Context 'When called with all parameters when on Nano Server' {
+                    It 'Should call Set-TargetResourceOnNanoServer' {
+                        Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
 
-                    Set-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+                        Set-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
 
-                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                    Assert-MockCalled -CommandName 'Set-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                        Assert-MockCalled -CommandName 'Set-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                    }
                 }
             }
 
-            Describe 'Test-TargetResource' {
+            Describe 'GroupResource\Test-TargetResource' -Tag 'Test' {
                 Mock -CommandName 'Assert-GroupNameValid' -MockWith { }
                 Mock -CommandName 'Test-IsNanoServer' -MockWith { return $false }
                 Mock -CommandName 'Test-TargetResourceOnFullSKU' -MockWith { }
                 Mock -CommandName 'Test-TargetResourceOnNanoServer' -MockWith { }
 
-                It 'Should call Assert-GroupNameValid with the given group name' {
-                    $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName
-                    Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                }
-
-                It 'Should call Test-TargetResourceOnFullSKU with all parameters when not on Nano Server' {
-                    $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
-
-                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                    Assert-MockCalled -CommandName 'Test-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                }
-
-                It 'Should call Test-TargetResourceOnNanoServer with all parameters when on Nano Server' {
-                    Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
-
-                    $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
-
-                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                    Assert-MockCalled -CommandName 'Test-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                }
-            }
-
-            Describe 'Assert-GroupNameValid' {
-                $invalidCharacters = @( '\', '/', '"', '[', ']', ':', '|', '<', '>', '+', '=', ';', ',', '?', '*', '@' ) |
-                    ForEach-Object { @{ InvalidCharacter = $_ } }
-
-                It "Should throw error if name contains invalid character '<InvalidCharacter>'" -TestCases $invalidCharacters {
-                    param
-                    (
-                        [Parameter(Mandatory = $true)]
-                        [System.String]
-                        $InvalidCharacter
-                    )
-
-                    $invalidGroupName = ('Invalid' + $invalidCharacter + 'Group')
-                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
-                }
-
-                $invalidGroups = @(
-                    @{
-                        InvalidGroupName = '    '
-                        InvalidGroupDescription = 'only whitespace'
-                    },
-                    @{
-                        InvalidGroupName = '....'
-                        InvalidGroupDescription = 'only dots'
-                    },
-                    @{
-                        InvalidGroupName = '..    ..'
-                        InvalidGroupDescription = 'only whitespace and dots'
+                Context 'When called with the given group name' {
+                    It 'Should call Assert-GroupNameValid' {
+                        $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName
+                        Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
                     }
-                )
-
-                It 'Should throw if name contains <InvalidGroupDescription>' -TestCases $invalidGroups {
-                    param
-                    (
-                        [Parameter(Mandatory = $true)]
-                        [System.String]
-                        $InvalidGroupDescription,
-
-                        [Parameter(Mandatory = $true)]
-                        [System.String]
-                        $InvalidGroupName
-                    )
-
-                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
                 }
 
-                It 'Should not throw if name contains whitespace and dots' {
-                    $invalidGroupName = '..  MyGroup  ..'
-                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Not -Throw
+                Context 'When called with all parameters when not on Nano Server' {
+                    It 'Should call Test-TargetResourceOnFullSKU' {
+                        $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+
+                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                        Assert-MockCalled -CommandName 'Test-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                    }
+                }
+
+                Context 'When called with all parameters when on Nano Server' {
+                    It 'Should call Test-TargetResourceOnNanoServer' {
+                        Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
+
+                        $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+
+                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                        Assert-MockCalled -CommandName 'Test-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                    }
                 }
             }
 
-            Describe 'Test-IsLocalMachine' {
+            Describe 'GroupResource\Assert-GroupNameValid' {
+                Context 'When called with an invalid group name' {
+                    $invalidCharacters = @( '\', '/', '"', '[', ']', ':', '|', '<', '>', '+', '=', ';', ',', '?', '*', '@' ) |
+                        ForEach-Object { @{ InvalidCharacter = $_ } }
+
+                    It 'Should throw error if name contains invalid character "<InvalidCharacter>"' -TestCases $invalidCharacters {
+                        param
+                        (
+                            [Parameter(Mandatory = $true)]
+                            [System.String]
+                            $InvalidCharacter
+                        )
+
+                        $invalidGroupName = ('Invalid' + $invalidCharacter + 'Group')
+                        { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
+                    }
+
+                    $invalidGroups = @(
+                        @{
+                            InvalidGroupName = '    '
+                            InvalidGroupDescription = 'only whitespace'
+                        },
+                        @{
+                            InvalidGroupName = '....'
+                            InvalidGroupDescription = 'only dots'
+                        },
+                        @{
+                            InvalidGroupName = '..    ..'
+                            InvalidGroupDescription = 'only whitespace and dots'
+                        }
+                    )
+
+                    It 'Should throw if name contains <InvalidGroupDescription>' -TestCases $invalidGroups {
+                        param
+                        (
+                            [Parameter(Mandatory = $true)]
+                            [System.String]
+                            $InvalidGroupDescription,
+
+                            [Parameter(Mandatory = $true)]
+                            [System.String]
+                            $InvalidGroupName
+                        )
+
+                        { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
+                    }
+                }
+
+                Context 'When called with a valid group name' {
+                    It 'Should not throw if name contains whitespace and dots' {
+                        $invalidGroupName = '..  MyGroup  ..'
+                        { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Not -Throw
+                    }
+                }
+            }
+
+            Describe 'GroupResource\Test-IsLocalMachine' {
                 Mock -CommandName 'Get-CimInstance' -MockWith { }
 
-                $localMachineScopes = @( '.', $env:computerName, 'localhost', '127.0.0.1' )
+                Context 'When called with a scope name that resolves to the local machine' {
+                    $localMachineScopes = @(
+                        @{ localMachineScope = '.' }
+                        @{ localMachineScope = $ENV:COMPUTERNAME }
+                        @{ localMachineScope = 'localhost' }
+                        @{ localMachineScope = '127.0.0.1' }
+                    )
 
-                foreach ($localMachineScope in $localMachineScopes)
-                {
-                    It "Should return true for local machine scope $localMachineScope" {
-                        Test-IsLocalMachine -Scope $localMachineScope | Should -Be $true
+                    It 'Should return true for local machine scope "<LocalMachineScope>"' -TestCases $localMachineScopes {
+                        param
+                        (
+                            [Parameter(Mandatory = $true)]
+                            [System.String]
+                            $LocalMachineScope
+                        )
+
+                        Test-IsLocalMachine -Scope $LocalMachineScope | Should -Be $true
+                    }
+
+                    $customLocalIPAddress = '123.4.5.6'
+
+                    It 'Should return true if custom local IP address provided and Get-CimInstance contains matching IP address' {
+                        Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @($customLocalIPAddress, '789.1.2.3')} }
+
+                        Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $true
                     }
                 }
 
-                $customLocalIPAddress = '123.4.5.6'
+                Context 'When called with a scope name that does not resolve to the local machine' {
+                    $customLocalIPAddress = '123.4.5.6'
 
-                It 'Should return false if custom local IP address provided and Get-CimInstance returns null' {
-                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
-                }
+                    It 'Should return false if custom local IP address provided and Get-CimInstance returns null' {
+                        Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
+                    }
 
-                It 'Should return true if custom local IP address provided and Get-CimInstance contains matching IP address' {
-                    Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @($customLocalIPAddress, '789.1.2.3')} }
+                    It 'Should return false if custom local IP address provided and Get-CimInstance do not contain matching IP addresses' {
+                        Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @('789.1.2.3')} }
 
-                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $true
-                }
-
-                It 'Should return false if custom local IP address provided and Get-CimInstance do not contain matching IP addresses' {
-                    Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @('789.1.2.3')} }
-
-                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
+                        Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
+                    }
                 }
             }
 
-            Describe 'Split-MemberName' {
-                Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
+            Describe 'GroupResource\Split-MemberName' {
+                Context 'When called with the MemberName in the domain\username format with the local scope' {
+                    It 'Should return the local scope and the username' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                It 'Should split a member name in the domain\username format with the machine domain' {
-                    $testMemberName = 'domain\username'
-                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+                        $testMemberName = 'domain\username'
+                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
 
-                    Assert-MockCalled -CommandName 'Test-IsLocalMachine'
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine'
 
-                    $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
+                        $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
+                    }
                 }
 
-                Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                Context 'When called with a MemberName in the domain\username format with the domain scope' {
+                    It 'Should return the specified domain and the username' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
 
-                It 'Should split a member name in the domain\username format with a custom domain' {
-                    $testMemberName = 'domain\username'
-                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+                        $testMemberName = 'domain\username'
+                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
 
-                    Assert-MockCalled -CommandName 'Test-IsLocalMachine'
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine'
 
-                    $splitMemberNameResult | Should -Be @( 'domain', 'username' )
+                        $splitMemberNameResult | Should -Be @( 'domain', 'username' )
+                    }
                 }
 
-                It 'Should split a member name in the username@domain format' {
-                    $testMemberName = 'username@domain'
-                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+                Context 'When called with a MemberName in the username@domain format with the domain scope' {
+                    It 'Should return the specified domain and the username' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
 
-                    $splitMemberNameResult | Should -Be @( 'domain', 'username' )
+                        $testMemberName = 'username@domain'
+                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                        $splitMemberNameResult | Should -Be @( 'domain', 'username' )
+                    }
                 }
 
-                It 'Should split a member name in the CN=username,DC=domain format with local domain' {
-                    $testMemberName = 'CN=username,DC=domain'
-                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+                Context 'When called with a MemberName in the CN=username,DC=domain format with local scope' {
+                    It 'Should return the local scope and the username' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
 
-                    $splitMemberNameResult | Should -Be @( $script:localDomain, $testMemberName )
+                        $testMemberName = 'CN=username,DC=domain'
+                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                        $splitMemberNameResult | Should -Be @( $script:localDomain, $testMemberName )
+                    }
                 }
 
-                It 'Should split a member name in the CN=username,DC=domain format with outisde domain' {
-                    $testMemberName = 'CN=username,DC=domain,DC=com'
-                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+                Context 'When called with a MemberName in the CN=username,DC=domain format with domain scope' {
+                    It 'Should return the specified domain and the username' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
 
-                    $splitMemberNameResult | Should -Be @( 'domain', $testMemberName )
+                        $testMemberName = 'CN=username,DC=domain,DC=com'
+                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                        $splitMemberNameResult | Should -Be @( 'domain', $testMemberName )
+                    }
                 }
 
-                It 'Should split a member name in the local username format' {
-                    $testMemberName = 'username'
-                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+                Context 'When called with a MemberName in the without a scope specified' {
+                    It 'Should return the local scope and the username' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
 
-                    $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
+                        $testMemberName = 'username'
+                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                        $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
+                    }
                 }
             }
 
             if ($script:onNanoServer)
             {
-                Describe 'Get-TargetResourceOnNanoServer' {
+                Describe 'GroupResource\Get-TargetResourceOnNanoServer' {
                     $testMembers = @('User1', 'User2')
 
-                    Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @() }
-
-                    It 'Should return Ensure as Absent when Get-LocalGroup throws a GroupNotFound exception' {
-                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
-
-                        $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
-
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-
-                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                        $getTargetResourceResult.Keys.Count | Should -Be 2
-                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                    BeforeEach {
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @() }
                     }
 
-                    It 'Should throw an error when Get-LocalGroup throws an exception other than GroupNotFound' {
-                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
+                    Context 'When Get-LocalGroup throws a GroupNotFound exception' {
+                        It 'Should return Ensure as Absent' {
+                            Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
 
-                        { $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName } | Should -Throw $script:testErrorMessage
+                            $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+
+                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                            $getTargetResourceResult.Keys.Count | Should -Be 2
+                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                            $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                        }
                     }
 
-                    It 'Should return correct hashtable values when Get-LocalGroup returns a valid, existing group without members' {
-                        $script:testLocalGroup.Description = $script:testGroupDescription
+                    Context 'When Get-LocalGroup throws a GroupNotFound exception' {
+                        It 'Should throw an error' {
+                            Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
-                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                            { $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName } | Should -Throw $script:testErrorMessage
 
-                        $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
-
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
-
-                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                        $getTargetResourceResult.Keys.Count | Should -Be 4
-                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should -Be 'Present'
-                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should -Be $null
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        }
                     }
 
-                    It 'Should return correct hashtable values when Get-LocalGroup returns a valid, existing group with members' {
-                        $script:testLocalGroup.Description = $script:testGroupDescription
+                    Context 'When Get-LocalGroup returns a valid, existing group without members' {
+                        It 'Should return correct hashtable values' {
+                            $script:testLocalGroup.Description = $script:testGroupDescription
 
-                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return $testMembers }
+                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
 
-                        $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
+                            $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
 
-                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                        $getTargetResourceResult.Keys.Count | Should -Be 4
-                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should -Be 'Present'
-                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should -Be $testMembers
+                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                            $getTargetResourceResult.Keys.Count | Should -Be 4
+                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                            $getTargetResourceResult.Ensure | Should -Be 'Present'
+                            $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                            $getTargetResourceResult.Members | Should -Be $null
+                        }
+                    }
+
+                    Context 'When Get-LocalGroup returns a valid, existing group with members' {
+                        It 'Should return correct hashtable values' {
+                            $script:testLocalGroup.Description = $script:testGroupDescription
+
+                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return $testMembers }
+
+                            $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
+
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
+
+                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                            $getTargetResourceResult.Keys.Count | Should -Be 4
+                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                            $getTargetResourceResult.Ensure | Should -Be 'Present'
+                            $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                            $getTargetResourceResult.Members | Should -Be $testMembers
+                        }
                     }
                 }
 
-                Describe 'Set-TargetResourceOnNanoServer' {
+                Describe 'GroupResource\Set-TargetResourceOnNanoServer' {
                     Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
                     Mock -CommandName 'New-LocalGroup' -MockWith { return $script:testLocalGroup }
                     Mock -CommandName 'Set-LocalGroup' -MockWith { }
@@ -396,530 +471,550 @@ try
                     Mock -CommandName 'Add-LocalGroupMember' -MockWith { }
                     Mock -CommandName 'Remove-LocalGroupMember' -MockWith { }
 
-                    It 'Should not attempt to remove an absent group when Ensure is Absent' {
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent'
+                    Context 'When called with Ensure is Absent' {
+                        It 'Should not attempt to remove an absent group' {
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-LocalGroup' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-LocalGroup' -Times 0 -Scope 'It'
+                        }
+
+                        It 'Should remove an existing group' {
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent'
+
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName } -Scope 'It'
+                        }
                     }
 
-                    It 'Should create an empty group' {
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present'
+                    Context 'When called with Ensure is Present' {
+                        It 'Should create an empty group' {
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        }
 
-                    It 'Should create an empty group with a description' {
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present'
+                        It 'Should create an empty group with a description' {
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Set-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName -and $Description -eq $script:testGroupDescription }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Set-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName -and $Description -eq $script:testGroupDescription }
+                        }
 
-                    It 'Should create a group with one local member using Members' {
-                        $testMembers = @( $script:testMemberName1 )
+                        It 'Should create a group with one local member using Members' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        }
 
-                    It 'Should create a group with two local members using Members' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        It 'Should create a group with two local members using Members' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    It 'Should create a group with one local member using MembersToInclude' {
-                        $testMembers = @( $script:testMemberName1 )
+                        It 'Should create a group with one local member using MembersToInclude' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        }
 
-                    It 'Should create a group with two local members using MembersToInclude' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        It 'Should create a group with two local members using MembersToInclude' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
-                    It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
-                    }
+                        It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
+                            { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
+                        }
 
-                    Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
 
-                    It 'Should add a member to an existing group with no members using Members' {
-                        $testMembers = @( $script:testMemberName1 )
+                        It 'Should add a member to an existing group with no members using Members' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        }
 
-                    It 'Should add two members to an existing group with one of the members using Members' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        It 'Should add two members to an existing group with one of the members using Members' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    It 'Should not modify group with no members if Members is empty' {
-                        $testMembers = @( )
+                        It 'Should not modify group with no members if Members is empty' {
+                            $testMembers = @( )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
-                    }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                        }
 
-                    It 'Should add a member to an existing group with no members using MembersToInclude' {
-                        $testMembers = @( $script:testMemberName1 )
+                        It 'Should add a member to an existing group with no members using MembersToInclude' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        }
 
-                    It 'Should add two members to an existing group with one of the members using MembersToInclude' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        It 'Should add two members to an existing group with one of the members using MembersToInclude' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
 
-                    It 'Should remove a member from an existing group using Members' {
-                        $testMembers = @( $script:testMemberName1 )
+                        It 'Should remove a member from an existing group using Members' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    It 'Should clear group members from an existing group using Members' {
-                        $testMembers = @( )
+                        It 'Should clear group members from an existing group using Members' {
+                            $testMembers = @( )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    It 'Should remove a member from an existing group using MembersToExclude' {
-                        $testMembers = @( $script:testMemberName2 )
+                        It 'Should remove a member from an existing group using MembersToExclude' {
+                            $testMembers = @( $script:testMemberName2 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    It 'Should add a user and remove a user using Members' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
+                        It 'Should add a user and remove a user using Members' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName3 }
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName3 }
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    It 'Should add a user and remove a user using MembersToInclude and MembersToExclude at the same time' {
-                        $testMembersToInclude = @( $script:testMemberName3 )
-                        $testMembersToExclude = @( $script:testMemberName2 )
+                        It 'Should add a user and remove a user using MembersToInclude and MembersToExclude at the same time' {
+                            $testMembersToInclude = @( $script:testMemberName3 )
+                            $testMembersToExclude = @( $script:testMemberName2 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMemberstoInclude -MembersToExclude $testMemberstoExclude -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMemberstoInclude -MembersToExclude $testMemberstoExclude -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName3 }
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName3 }
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                        }
 
-                    It 'Should throw if Members and MembersToInclude are both specified' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-                        $testMembersToInclude = @( $script:testMemberName3 )
+                        It 'Should throw if Members and MembersToInclude are both specified' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                            $testMembersToInclude = @( $script:testMemberName3 )
 
-                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
-                    }
+                            { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
 
-                    It 'Should throw if Members and MembersToExclude are both specified' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-                        $testMembersToExclude = @( $script:testMemberName3 )
+                        It 'Should throw if Members and MembersToExclude are both specified' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                            $testMembersToExclude = @( $script:testMemberName3 )
 
-                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                    }
+                            { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
 
-                    It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
-                        $testMembersToInclude = @( $script:testMemberName1 )
-                        $testMembersToExclude = @( $script:testMemberName1 )
+                        It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
+                            $testMembersToInclude = @( $script:testMemberName1 )
+                            $testMembersToExclude = @( $script:testMemberName1 )
 
-                        $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
+                            $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
 
-                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                    }
+                            { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
 
-                    It 'Should not modify group if member specified by MembersToInclude is already in group' {
-                        $testMembers = @( $script:testMemberName1 )
+                        It 'Should not modify group if member specified by MembersToInclude is already in group' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
-                    }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                        }
 
-                    It 'Should not modify group if member specified by MembersToExclude is not in group' {
-                        $testMembers = @( $script:testMemberName3 )
+                        It 'Should not modify group if member specified by MembersToExclude is not in group' {
+                            $testMembers = @( $script:testMemberName3 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
-                    }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                        }
 
-                    It 'Should not modify group if members specified by Members match group members' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        It 'Should not modify group if members specified by Members match group members' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
-                    }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                        }
 
-                    It 'Should not modify group if MembersToInclude is empty' {
-                        $testMembers = @( )
+                        It 'Should not modify group if MembersToInclude is empty' {
+                            $testMembers = @( )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
-                    }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                        }
 
-                    It 'Should not modify group if MembersToExclude is empty' {
-                        $testMembers = @( )
+                        It 'Should not modify group if MembersToExclude is empty' {
+                            $testMembers = @( )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
-                    }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                        }
 
-                    It 'Should not modify group if both MembersToInclude and MembersToExclude are empty' {
-                        $testMembers = @( )
+                        It 'Should not modify group if both MembersToInclude and MembersToExclude are empty' {
+                            $testMembers = @( )
 
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -MembersToExclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -MembersToExclude $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
-                    }
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                        }
 
-                    It 'Should remove an existing group when Ensure is Absent' {
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent'
+                        It 'Should not modify group if no changes were made' {
+                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName } -Scope 'It'
-                    }
-
-                    It 'Should not modify group if no changes were made' {
-                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Set-LocalGroup' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Set-LocalGroup' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
+                        }
                     }
                 }
 
-                Describe 'Test-TargetResourceOnNanoServer' {
+                Describe 'GroupResource\Test-TargetResourceOnNanoServer' {
                     Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
                     Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { }
 
-                    It 'Should return true for an absent group when Ensure is Absent' {
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
+                    Context 'When called with Ensure is Absent' {
+                        It 'Should return true for an absent group' {
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        }
+
+                        It 'Should return false for an existing group when Ensure is Absent' {
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
+
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        }
+
                     }
 
-                    It 'Should return false for an absent group when Ensure is Present' {
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
+                    Context 'When called with Ensure is Present' {
+                        It 'Should return false for an absent group when Ensure is Present' {
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        }
 
-                    Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
-                    It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
-                    }
+                        It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
+                            { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
+                        }
 
-                    Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
 
-                    It 'Should return true for an existing group when Ensure is Present' {
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
+                        It 'Should return true for an existing group when Ensure is Present' {
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                    }
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        }
 
-                    It 'Should return false for an existing group when Ensure is Absent' {
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
+                        It 'Should return true for an existing group with a matching description' {
+                            $script:testLocalGroup.Description = $script:testGroupDescription
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
 
-                    It 'Should return true for an existing group with a matching description' {
-                        $script:testLocalGroup.Description = $script:testGroupDescription
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
+                        It 'Should return false for an existing  group with a mismatching description' {
+                            $script:testLocalGroup.Description = $script:testGroupDescription
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
 
-                    It 'Should return false for an existing  group with a mismatching description' {
-                        $script:testLocalGroup.Description = $script:testGroupDescription
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
+                        It 'Should return true with matching empty members when using Members' {
+                            $testMembers = @( )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
 
-                    It 'Should return true with matching empty members when using Members' {
-                        $testMembers = @( )
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+                        It 'Should return false with mismatching number of members when using Members' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
 
-                    It 'Should return false with mismatching number of members when using Members' {
-                        $testMembers = @( $script:testMemberName1 )
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+                        It 'Should return false with missing member when using MembersToInclude' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
 
-                    It 'Should return false with missing member when using MembersToInclude' {
-                        $testMembers = @( $script:testMemberName1 )
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
+                        It 'Should return true with missing member when using MembersToExclude' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
 
-                    It 'Should return true with missing member when using MembersToExclude' {
-                        $testMembers = @( $script:testMemberName1 )
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
+                        It 'Should return false when group contains member specified by MemberstoExclude' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                    Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
 
-                    It 'Should return false when group contains member specified by MemberstoExclude' {
-                        $testMembers = @( $script:testMemberName1 )
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
+                        It 'Should return true when group contains member specified by MembersToInclude' {
+                            $testMembers = @( $script:testMemberName1 )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
 
-                    It 'Should return true when group contains member specified by MembersToInclude' {
-                        $testMembers = @( $script:testMemberName1 )
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
+                        It 'Should return true when group members match Members' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
 
-                    It 'Should return true when group members match Members' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+                        It 'Should return false when group members do not match Members' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
+                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
 
-                    It 'Should return false when group members do not match Members' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
+                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
 
-                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+                        It 'Should throw if Members and MembersToInclude are both specified' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                            $testMembersToInclude = @( $script:testMemberName3 )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
+                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
 
-                    It 'Should throw if Members and MembersToInclude are both specified' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-                        $testMembersToInclude = @( $script:testMemberName3 )
+                            { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
 
-                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+                        It 'Should throw if Members and MembersToExclude are both specified' {
+                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                            $testMembersToExclude = @( $script:testMemberName3 )
 
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
-                    }
+                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
 
-                    It 'Should throw if Members and MembersToExclude are both specified' {
-                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-                        $testMembersToExclude = @( $script:testMemberName3 )
+                            { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
 
-                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+                        It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
+                            $testMembersToInclude = @( $script:testMemberName1 )
+                            $testMembersToExclude = @( $script:testMemberName1 )
 
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                    }
+                            $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
 
-                    It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
-                        $testMembersToInclude = @( $script:testMemberName1 )
-                        $testMembersToExclude = @( $script:testMemberName1 )
-
-                        $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
-
-                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                            { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
                     }
                 }
 
-                Describe 'Get-MembersOnNanoServer' {
-                    Mock -CommandName 'Get-LocalGroupMember' -MockWith { }
+                Describe 'GroupResource\Get-MembersOnNanoServer' {
+                    Context 'When called with a Group that has no members' {
+                        Mock -CommandName 'Get-LocalGroupMember' -MockWith { }
 
-                    It 'Should return nothing if group does not have members' {
-                        Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be $null
+                        It 'Should return nothing' {
+                            Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be $null
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
                     }
 
-                    $testDomainUser1 = @{
-                        Name = 'TestDomainUser1'
-                        PrincipalSource = 'NotLocal'
-                    }
+                    Context 'When called with a Group that has local and domain members' {
+                        $testDomainUser1 = @{
+                            Name = 'TestDomainUser1'
+                            PrincipalSource = 'NotLocal'
+                        }
 
-                    $testDomainUser2 = @{
-                        Name = 'TestDomainUser2'
-                        PrincipalSource = 'Local'
-                    }
+                        $testDomainUser2 = @{
+                            Name = 'TestDomainUser2'
+                            PrincipalSource = 'Local'
+                        }
 
-                    Mock -CommandName 'Get-LocalGroupMember' -MockWith { return @( $testDomainUser1, $testDomainUser2 ) }
+                        Mock -CommandName 'Get-LocalGroupMember' -MockWith { return @( $testDomainUser1, $testDomainUser2 ) }
 
-                    It 'Should return all local members and ignore non-local members' {
-                        Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be @( $testDomainUser2.Name )
+                        It 'Should return all local members and ignore domain members' {
+                            Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be @( $testDomainUser2.Name )
 
-                        Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
                     }
                 }
             }
             else
             {
-                Describe 'Get-TargetResourceOnFullSKU' {
+                Describe 'GroupResource\Get-TargetResourceOnFullSKU' {
                     $testMembers = @($script:testuserPrincipal1.Name, $script:testuserPrincipal2.Name)
 
-                    Mock -CommandName 'Get-Group' -MockWith { }
                     Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return @() }
                     Mock -CommandName 'Remove-DisposableObject' -MockWith { }
 
-                    It 'Should return Ensure as Absent when Get-Group returns null' {
-                        $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
+                    Context 'When called with a Group that does not exist' {
+                        It 'Should return expected values and call expected mocks' {
+                            Mock -CommandName 'Get-Group' -MockWith { }
 
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
 
-                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                        $getTargetResourceResult.Keys.Count | Should -Be 2
-                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+
+                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                            $getTargetResourceResult.Keys.Count | Should -Be 2
+                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                            $getTargetResourceResult.Ensure | Should -Be 'Absent'
+                        }
                     }
 
-                    It 'Should return correct hashtable values when Get-Group returns a valid, existing group without members' {
-                        $script:testGroup.Description = $script:testGroupDescription
+                    Context 'When called with a valid, existing Group containing no members' {
+                        It 'Should return expected values and call expected mocks' {
+                            $script:testGroup.Description = $script:testGroupDescription
 
-                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
 
-                        $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
+                            $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
 
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
 
-                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                        $getTargetResourceResult.Keys.Count | Should -Be 4
-                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should -Be 'Present'
-                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should -Be $null
+                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                            $getTargetResourceResult.Keys.Count | Should -Be 4
+                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                            $getTargetResourceResult.Ensure | Should -Be 'Present'
+                            $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                            $getTargetResourceResult.Members | Should -Be $null
+                        }
                     }
 
-                    It 'Should return correct hashtable values when Get-Group returns a valid, existing group with members' {
-                        $testGroup.Description = $script:testGroupDescription
+                    Context 'When called with a valid, existing Group with containing members' {
+                        It 'Should return expected values and call expected mocks' {
+                            $testGroup.Description = $script:testGroupDescription
 
-                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-                        Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return $testMembers }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+                            Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return $testMembers }
 
-                        $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
+                            $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
 
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
 
-                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                        $getTargetResourceResult.Keys.Count | Should -Be 4
-                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                        $getTargetResourceResult.Ensure | Should -Be 'Present'
-                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                        $getTargetResourceResult.Members | Should -Be $testMembers
+                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                            $getTargetResourceResult.Keys.Count | Should -Be 4
+                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                            $getTargetResourceResult.Ensure | Should -Be 'Present'
+                            $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                            $getTargetResourceResult.Members | Should -Be $testMembers
+                        }
                     }
                 }
 
-                Describe 'Set-TargetResourceOnFullSKU' {
+                Context 'GroupResource\Set-TargetResourceOnFullSKU' {
                     Mock -CommandName 'Get-Group' -MockWith { }
                     Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
                     Mock -CommandName 'ConvertTo-UniquePrincipalsList' -MockWith {
@@ -948,287 +1043,16 @@ try
                     Mock -CommandName 'Remove-GroupMember' -MockWith { }
                     Mock -CommandName 'Remove-Group' -MockWith { }
                     Mock -CommandName 'Save-Group' -MockWith { }
-
                     Mock -CommandName 'Remove-DisposableObject' -MockWith { }
                     Mock -CommandName 'Get-PrincipalContext' -MockWith { return $script:testPrincipalContext }
-
-                    It 'Should not attempt to remove an absent group when Ensure is Absent' {
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName } -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
-                    }
-
-                    It 'Should create an empty group' {
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should create an empty group with a description' {
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Group.Description -eq $script:testGroupDescription }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should create a group with one local member using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
-
-                        Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $MemberNames -eq $testMembers }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should create a group with two local members using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                        Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null  }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should create a group with one local member using MembersToInclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
-
-                        Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $MemberNames -eq $testMembers }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should create a group with two local members using MembersToInclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                        Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames)  -eq $null  }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                    It 'Should add a member to an existing group with no members using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @() }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should add two members to an existing group with one of the members using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should add a member to an existing group with no members using MembersToInclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @() }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should add two members to an existing group with one of the members using MembersToInclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should remove a member from an existing group using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should clear group members from an existing group using Members' {
-                        $testMembers = @( )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should remove a member from an existing group using MembersToExclude' {
-                        $testMembers = @( $script:testUserPrincipal2.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should add a user and remove a user using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal3.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal3 }
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should add a user and remove a user using MembersToInclude and MembersToExclude at the same time' {
-                        $testMembersToInclude = @( $script:testUserPrincipal3.Name )
-                        $testMembersToExclude = @( $script:testUserPrincipal2.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembersToInclude -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembersToExclude -DifferenceObject $MemberNames) -eq $null }
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal3 }
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                    }
-
-                    It 'Should throw if Members and MembersToInclude are both specified' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-                        $testMembersToInclude = @( $script:testUserPrincipal3.Name )
-
-                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
-
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
-                    }
-
-                    It 'Should throw if Members and MembersToExclude are both specified' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-                        $testMembersToExclude = @( $script:testUserPrincipal3.Name )
-
-                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
-
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                    }
-
-                    It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
-                        $testMembersToInclude = @( $script:testUserPrincipal1.Name )
-                        $testMembersToExclude = @( $script:testUserPrincipal1.Name )
-
-                        $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
-
-                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                    }
-
-                    It 'Should not modify group if member specified by MembersToInclude is already in group' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+                    Mock -CommandName 'Get-Group' -MockWith { }
+
+                    function Assert-GroupMembersNotChanged
+                    {
+                        [CmdletBinding()]
+                        param
+                        (
+                        )
 
                         Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
                         Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
@@ -1237,133 +1061,475 @@ try
                         Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
                     }
 
-                    It 'Should not modify group if member specified by MembersToExclude is not in group' {
-                        $testMembers = @( $script:testUserPrincipal3.Name )
+                    Context 'When Ensure is absent and the group does not exist' {
+                        It 'Should not attempt to remove an absent group' {
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent'
 
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName } -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
+                        }
                     }
 
-                    It 'Should not modify group if members specified by Members match group members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                    Context 'When Ensure is absent and the group exists' {
+                        It 'Should remove an existing group' {
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
 
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent'
 
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName } -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
+                        }
                     }
 
-                    It 'Should not modify group if MembersToInclude is empty' {
-                        $testMembers = @( )
+                    Context 'When Ensure is present and the group does not exist' {
+                        It 'Should create an empty group' {
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present'
 
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should not modify group if MembersToExclude is empty' {
-                        $testMembers = @( )
+                    Context 'When Ensure is present and the group does not exist and Description is passed' {
+                        It 'Should create an empty group with a description' {
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present'
 
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( ) }
-
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Group.Description -eq $script:testGroupDescription }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should not modify group if both MembersToInclude and MembersToExclude are empty' {
-                        $testMembers = @( )
+                    Context 'When Ensure is present and the group does not exist and Members is passed with one local member' {
+                        It 'Should create a group with one local member' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( ) }
+                            Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
 
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -MembersToExclude $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $MemberNames -eq $testMembers }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should not modify group with no members if Members is empty' {
-                        $testMembers = @( )
+                    Context 'When Ensure is present and the group does not exist and Members is passed with two local members' {
+                        It 'Should create a group with two local members' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
 
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
+                            Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
 
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null  }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should remove an existing group when Ensure is Absent' {
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent'
+                    Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with one local member' {
+                        It 'Should create a group with one local member' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName } -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
+                            Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $MemberNames -eq $testMembers }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should not save group if no changes were made' {
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present'
+                    Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with two local members' {
+                        It 'Should create a group with two local members' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
+                            Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames)  -eq $null  }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should pass Credential to all appropriate functions when using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                    Context 'When Ensure is present and the group exists with no members and Members is passed with one member' {
+                        It 'Should add a member to an existing group' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @() }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
 
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should pass Credential to all appropriate functions when using MembersToInclude and MembersToExclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                    Context 'When Ensure is present and the group exists with one member missing from Members list passed' {
+                        It 'Should add a member to an existing group' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
 
-                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @() }
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
 
-                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                            Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with no members and MembersToInclude is passed with one member' {
+                        It 'Should add a member to an existing group' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
+
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with one member missing from Members list passed' {
+                        It 'Should add a member to an existing group' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                            Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with one member not in the Members list passed' {
+                        It 'Should remove a member from an existing group' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with containing members and an empty Members list passed' {
+                        It 'Should clear all members from an existing group' {
+                            $testMembers = @( )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Clear-GroupMembers' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with a member contained in the MembersToExclude list passed' {
+                        It 'Should remove a member from an existing group' {
+                            $testMembers = @( $script:testUserPrincipal2.Name )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with Members passed that require one member to be added and one removed' {
+                        It 'Should add a user and remove a user' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal3.Name )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal3 }
+                            Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with MembersToInclude and MembersToExclude passed that require one member to be added and one removed' {
+                        It 'Should add a user and remove a user' {
+                            $testMembersToInclude = @( $script:testUserPrincipal3.Name )
+                            $testMembersToExclude = @( $script:testUserPrincipal2.Name )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembersToInclude -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembersToExclude -DifferenceObject $MemberNames) -eq $null }
+                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal3 }
+                            Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
+                    }
+
+                    Context 'When Members and MembersToInclude are both specified' {
+                        It 'Should throw expected exception' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                            $testMembersToInclude = @( $script:testUserPrincipal3.Name )
+
+                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+
+                            { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
+                    }
+
+                    Context 'When Members and MembersToExclude are both specified' {
+                        It 'Should throw expected exception' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                            $testMembersToExclude = @( $script:testUserPrincipal3.Name )
+
+                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+
+                            { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
+                    }
+
+                    Context 'When MembersToInclude and MembersToExclude both contain the same member' {
+                        It 'Should throw expected exception' {
+                            $testMembersToInclude = @( $script:testUserPrincipal1.Name )
+                            $testMembersToExclude = @( $script:testUserPrincipal1.Name )
+
+                            $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
+
+                            { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with members already containing all principals in the MembersToInclude' {
+                        It 'Should not modify the group' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                            Assert-GroupMembersNotChanged
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with members not containing any of the principals in the MembersToExclude' {
+                        It 'Should not modify the group' {
+                            $testMembers = @( $script:testUserPrincipal3.Name )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                            Assert-GroupMembersNotChanged
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with members that match the Members' {
+                        It 'Should not modify the group' {
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                            Assert-GroupMembersNotChanged
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with no members and the MembersToInclude is specified but Empty' {
+                        It 'Should not modify the group' {
+                            $testMembers = @( )
+
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                            Assert-GroupMembersNotChanged
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with no members and the MembersToExclude is specified but Empty' {
+                        It 'Should not modify the group' {
+                            $testMembers = @( )
+
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                            Assert-GroupMembersNotChanged
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with no members and both MembersToInclude and MembersToExclude are empty' {
+                        It 'Should not modify the group' {
+                            $testMembers = @( )
+
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -MembersToExclude $testMembers -Ensure 'Present'
+
+                            Assert-GroupMembersNotChanged
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists with no members and empty Members passed' {
+                        It 'Should not modify the group' {
+                            $testMembers = @( )
+
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                            Assert-GroupMembersNotChanged
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists and no changes are made to the group' {
+                        It 'Should not save group' {
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                            Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists and Credential is passed when using Members' {
+                        It 'Should pass Credential to all appropriate functions' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
+
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists and Credential is passed when using MembersToInclude' {
+                        It 'Should pass Credential to all appropriate functions' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
+
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        }
+                    }
+
+                    Context 'When Ensure is present and the group exists and Credential is passed when using MembersToExclude' {
+                        It 'Should pass Credential to all appropriate functions' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
+
+                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        }
                     }
                 }
 
-                Describe 'Test-TargetResourceOnFullSKU' {
-                    Mock -CommandName 'Get-Group' -MockWith { }
+                Describe 'GroupResource\Test-TargetResourceOnFullSKU' {
+                    Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
                     Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
                     Mock -CommandName 'ConvertTo-UniquePrincipalsList' -MockWith {
                         $memberPrincipals = @()
@@ -1389,278 +1555,331 @@ try
                     Mock -CommandName 'Remove-DisposableObject' -MockWith { }
                     Mock -CommandName 'Get-PrincipalContext' -MockWith { return $script:testPrincipalContext }
 
-                    It 'Should return true for an absent group when Ensure is Absent' {
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
+                    Context 'When Ensure is absent and the group does not exist' {
+                        It 'Should return true and expected mocks are called' {
+                            Mock -CommandName 'Get-Group' -MockWith { }
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return false for an absent group when Ensure is Present' {
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
+                    Context 'When Ensure is absent and the group exists' {
+                        It 'Should return false and expected mocks are called' {
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+                    Context 'When Ensure is present and the group does not exist' {
+                        It 'Should return false and expected mocks are called' {
+                            Mock -CommandName 'Get-Group' -MockWith { }
 
-                    It 'Should return true for an existing group when Ensure is Present' {
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return false for an existing group when Ensure is Absent' {
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
+                    Context 'When Ensure is present and the group exists' {
+                        It 'Should return true and expected mocks are called' {
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return true for an existing group with a matching description' {
-                        $script:testGroup.Description = $script:testGroupDescription
+                    Context 'When Ensure is present and the group exists and Description matches' {
+                        It 'Should return true and expected mocks are called' {
+                            $script:testGroup.Description = $script:testGroupDescription
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return false for an existing  group with a mismatching description' {
-                        $script:testGroup.Description = $script:testGroupDescription
+                    Context 'When Ensure is present and the group exists and Description does not match' {
+                        It 'Should return false and expected mocks are called' {
+                            $script:testGroup.Description = $script:testGroupDescription
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return true with matching empty members when using Members' {
-                        $testMembers = @( )
+                    Context 'When Ensure is present and the group exists and with no members and Members should be empty' {
+                        It 'Should return true and expected mocks are called' {
+                            $testMembers = @( )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return false with mismatching number of members when using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                    Context 'When Ensure is present and the group exists mismatching number of members when passing Members' {
+                        It 'Should return false and expected mocks are called' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return false with missing member when using MembersToInclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                    Context 'When Ensure is present and the group exists with missing member when passing MembersToInclude' {
+                        It 'Should return false and expected mocks are called' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return true with missing member when using MembersToExclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                    Context 'When Ensure is present and the group exists with missing member when passing MembersToExclude' {
+                        It 'Should return true and expected mocks are called' {
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                    Context 'When Ensure is present and the group exists containing member specified by MembersToExclude' {
+                        It 'Should return false and expected mocks are called' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                    It 'Should return false when group contains member specified by MemberstoExclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return true when group contains member specified by MembersToInclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                    Context 'When Ensure is present and the group exists containing member specified by MembersToInclude' {
+                        It 'Should return true and expected mocks are called' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return true when group members match Members' {
-                        $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
+                    Context 'When Ensure is present and the group exists and current members matches Members' {
+                        It 'Should return true and expected mocks are called' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+                            $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should return false when group members do not match Members' {
-                        $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal3 )
+                    Context 'When Ensure is present and the group exists and current members do not match Members' {
+                        It 'Should return false and expected mocks are called' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+                            $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal3 )
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        }
                     }
 
-                    It 'Should pass Credential to all appropriate functions when using Members' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                    Context 'When Credential is passed with Members' {
+                        It 'Should pass Credential to all appropriate functions' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                        $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                            $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                        }
                     }
 
-                    It 'Should pass Credential to all appropriate functions when using MembersToInclude and MembersToExclude' {
-                        $testMembers = @( $script:testUserPrincipal1.Name )
+                    Context 'When Credential is passed with MembersToInclude' {
+                        It 'Should pass Credential to all appropriate functions' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                        $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                            $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                        }
                     }
 
-                    It 'Should throw if Members and MembersToInclude are both specified' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-                        $testMembersToInclude = @( $script:testUserPrincipal3.Name )
+                    Context 'When Credential is passed with MembersToExclude' {
+                        It 'Should pass Credential to all appropriate functions' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+                            $testMembers = @( $script:testUserPrincipal1.Name )
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                            $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                        }
                     }
 
-                    It 'Should throw if Members and MembersToExclude are both specified' {
-                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-                        $testMembersToExclude = @( $script:testUserPrincipal3.Name )
+                    Context 'When Members and MembersToInclude are both specified' {
+                        It 'Should throw expected exception' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                            $testMembersToInclude = @( $script:testUserPrincipal3.Name )
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+
+                            { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
                     }
 
-                    It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
-                        $testMembersToInclude = @( $script:testUserPrincipal1.Name )
-                        $testMembersToExclude = @( $script:testUserPrincipal1.Name )
+                    Context 'When Members and MembersToExclude are both specified' {
+                        It 'Should throw expected exception' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                        $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
+                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                            $testMembersToExclude = @( $script:testUserPrincipal3.Name )
 
-                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+
+                            { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
+                    }
+
+                    Context 'When MembersToInclude and MembersToExclude both contain the same member' {
+                        It 'Should throw expected exception' {
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                            $testMembersToInclude = @( $script:testUserPrincipal1.Name )
+                            $testMembersToExclude = @( $script:testUserPrincipal1.Name )
+
+                            $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
+
+                            { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                        }
                     }
                 }
 
-                Describe 'Get-MembersOnFullSKU' {
+                Context 'GroupResource\Get-MembersOnFullSKU' {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                    Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
+                    Context 'When called with a group that does not have any members' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
 
-                    It 'Should return nothing if group does not have members' {
-                        Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
+                        It 'Should return nothing' {
+                            Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
 
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
-
-                    Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                    It 'Should return principal names for members without domains' {
-                        Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
-
-                    $testDomainUser1 = @{
-                        Name = 'TestDomainUser1'
-                        SamAccountName = 'TestSamAccountName1'
-                        ContextType = [System.DirectoryServices.AccountManagement.ContextType]::Domain
-                        Context = @{
-                            Name = 'TestDomain1'
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                         }
-                        StructuralObjectClass = 'Domain'
                     }
 
-                    $domainName2 = 'TestDomain2'
+                    Context 'When called with a group that has only local memebers' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
 
-                    $testDomainUser2 = @{
-                        Name = 'TestDomainUser2'
-                        SamAccountName = 'TestSamAccountName2'
-                        ContextType = [System.DirectoryServices.AccountManagement.ContextType]::Domain
-                        Context = @{
-                            Name = "$domainName2.WithDot"
+                        It 'Should return principal names' {
+                            Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                         }
-                        StructuralObjectClass = 'Computer'
                     }
 
-                    Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $testDomainUser1, $testDomainUser2 ) }
+                    Context 'When called with group that has domain members' {
+                        It 'Should return exepcted principal names with domains' {
+                            $testDomainUser1 = @{
+                                Name = 'TestDomainUser1'
+                                SamAccountName = 'TestSamAccountName1'
+                                ContextType = [System.DirectoryServices.AccountManagement.ContextType]::Domain
+                                Context = @{
+                                    Name = 'TestDomain1'
+                                }
+                                StructuralObjectClass = 'Domain'
+                            }
 
-                    It 'Should return principal names for members with domains' {
-                        $expectedName1 = "$($testDomainUser1.Context.Name)\$($testDomainUser1.SamAccountName)"
-                        $expectedName2 = "$($domainName2)\$($testDomainUser2.Name)"
+                            $domainName2 = 'TestDomain2'
 
-                        $expectedGetMembersResult = @( $expectedName1, $expectedName2 )
+                            $testDomainUser2 = @{
+                                Name = 'TestDomainUser2'
+                                SamAccountName = 'TestSamAccountName2'
+                                ContextType = [System.DirectoryServices.AccountManagement.ContextType]::Domain
+                                Context = @{
+                                    Name = "$domainName2.WithDot"
+                                }
+                                StructuralObjectClass = 'Computer'
+                            }
 
-                        $getMembersResult = Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            $expectedName1 = "$($testDomainUser1.Context.Name)\$($testDomainUser1.SamAccountName)"
+                            $expectedName2 = "$($domainName2)\$($testDomainUser2.Name)"
+                            $expectedGetMembersResult = @( $expectedName1, $expectedName2 )
 
-                        (Compare-Object -ReferenceObject $expectedGetMembersResult -DifferenceObject $getMembersResult) | Should -Be $null
+                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $testDomainUser1, $testDomainUser2 ) }
 
-                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            $getMembersResult = Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
+
+                            (Compare-Object -ReferenceObject $expectedGetMembersResult -DifferenceObject $getMembersResult) | Should -Be $null
+
+                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
                     }
                 }
 
-                Describe 'Get-MembersAsPrincipalsList' {
+                Describe 'GroupResource\Get-MembersAsPrincipalsList' {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
-
-                    Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { }
-
-                    Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -MockWith {
-                        return $ArgumentList[0]
-                    }
-
-                    Mock -CommandName 'Get-PrincipalContext' -MockWith { return $script:testPrincipalContext }
-                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
-
-                    Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' } -MockWith {
-                        return 'S-1-0-0'
-                    }
-
-                    Mock -CommandName 'Resolve-SidToPrincipal' -MockWith { return 'FakeSidValue' }
-
-                    It 'Should return empty list when there are no group members' {
-                        Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
-                        Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                    }
-
                     $memberDirectoryEntry1 = @{
                         Path = 'WinNT://domainname/accountname'
                         Properties = @{
@@ -1683,69 +1902,107 @@ try
                         Path ='accountname'
                     }
 
-                    Mock 'Get-GroupMembersFromDirectoryEntry' { return @( $memberDirectoryEntry3 ) }
+                    Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { }
 
-                    It 'Should ignore stale members' {
-                        $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables -WarningAction 'SilentlyContinue'
-                        $getMembersResult | Should -Be $null
-
-                        Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' }
+                    Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -MockWith {
+                        return $ArgumentList[0]
                     }
 
-                    Mock 'Get-GroupMembersFromDirectoryEntry' { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
+                    Mock -CommandName 'Get-PrincipalContext' -MockWith { return $script:testPrincipalContext }
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                    It 'Should return current members' {
-                        $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
-                        $getMembersResult.Count | Should -Be 2
-
-                        Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'domainname' }
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'machinename' }
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'domainname' }
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'machinename' }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue1' }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue2' }
-                        Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'domainname' }
-                        Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'machinename' }
+                    Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' } -MockWith {
+                        return 'S-1-0-0'
                     }
 
-                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                    Mock -CommandName 'Resolve-SidToPrincipal' -MockWith { return 'FakeSidValue' }
 
-                    It 'Should return current members with custom domain when prinicpal can be found' {
-                        $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
-                        $getMembersResult.Count | Should -Be 2
-
-                        Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'domainname' }
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'machinename' }
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'domainname' }
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'machinename' }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue1' }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue2' }
-                        Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'domainname' }
-                        Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'machinename' }
+                    Context 'When called with Group that contains no group members' {
+                        It 'Should return null and call expected mocks' {
+                            Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
+                            Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        }
                     }
 
-                    It 'Should pass Credential to appropriate functions' {
-                        $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+                    Context 'When called with Group that contains only stale group members' {
+                        It 'Should return null and call expected mocks' {
+                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry3 ) }
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential }
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential}
+                            $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables -WarningAction 'SilentlyContinue'
+                            $getMembersResult | Should -Be $null
+
+                            Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' }
+                        }
                     }
 
-                    Mock -CommandName 'Get-PrincipalContext' -MockWith { }
+                    Context 'When called with Group that contains two non-stale local members' {
+                        It 'Should return a list of two members and call expected mocks' {
+                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
 
-                    It 'Should throw when prinicpal context for custom domain cannot be found' {
-                        $errorMessage = ($script:localizedData.DomainCredentialsRequired -f 'accountname')
+                            $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            $getMembersResult.Count | Should -Be 2
 
-                        { Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables } | Should -Throw $errorMessage
+                            Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'domainname' }
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'machinename' }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'domainname' }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'machinename' }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue1' }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue2' }
+                            Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'domainname' }
+                            Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'machinename' }
+                        }
+                    }
+
+                    Context 'When called with Group that contains two non-stale domain members' {
+                        It 'Should return a list of two members and call expected mocks' {
+                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
+
+                            $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            $getMembersResult.Count | Should -Be 2
+
+                            Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'domainname' }
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'machinename' }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'domainname' }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'machinename' }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue1' }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue2' }
+                            Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'domainname' }
+                            Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'machinename' }
+                        }
+                    }
+
+                    Context 'When called with Credential' {
+                        It 'Should pass Credential to appropriate functions' {
+                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
+
+                            $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential}
+                        }
+                    }
+
+                    Context 'When called with a group that contains a principal that can not be found in the domain' {
+                        It 'Should throw expected exception' {
+                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
+                            Mock -CommandName 'Get-PrincipalContext' -MockWith { }
+
+                            $errorMessage = ($script:localizedData.DomainCredentialsRequired -f 'accountname')
+
+                            { Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables } | Should -Throw $errorMessage
+                        }
                     }
                 }
 
-                Describe 'ConvertTo-UniquePrincipalsList' {
+                Describe 'GroupResource\ConvertTo-UniquePrincipalsList' {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
@@ -1770,43 +2027,49 @@ try
                         }
                     }
 
-                    It 'Should not return duplicate local prinicpals' {
-                        $memberNames = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                    Context 'When called with a list of local principals that contains duplicates' {
+                        It 'Should not return duplicate local prinicpals' {
+                            $memberNames = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
 
-                        $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
-                        $uniquePrincipalsList | Should -Be @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
+                            $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            $uniquePrincipalsList | Should -Be @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
 
-                        foreach ($passedInMemberName in $memberNames)
-                        {
-                            Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $MemberName -eq $passedInMemberName }
+                            foreach ($passedInMemberName in $memberNames)
+                            {
+                                Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $MemberName -eq $passedInMemberName }
+                            }
                         }
                     }
 
-                    It 'Should not return duplicate domain prinicpals' {
-                        $memberNames = @( $testDomainUser1.Name, $testDomainUser1.Name )
+                    Context 'When called with a list of domain principals that contains duplicates' {
+                        It 'Should not return duplicate domain prinicpals' {
+                            $memberNames = @( $testDomainUser1.Name, $testDomainUser1.Name )
 
-                        $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
-                        $uniquePrincipalsList | Should -Be @( $testDomainUser1 )
+                            $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            $uniquePrincipalsList | Should -Be @( $testDomainUser1 )
 
-                        foreach ($passedInMemberName in $memberNames)
-                        {
-                            Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $MemberName -eq $passedInMemberName }
+                            foreach ($passedInMemberName in $memberNames)
+                            {
+                                Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $MemberName -eq $passedInMemberName }
+                            }
                         }
                     }
 
-                    It 'Should pass Credential to appropriate functions' {
-                        ConvertTo-UniquePrincipalsList -MemberNames @( $script:testUserPrincipal1 ) -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+                    Context 'When called with a list of domain principals that does not contain duplicates and a credential is passed' {
+                        It 'Should pass Credential to appropriate functions' {
+                            ConvertTo-UniquePrincipalsList -MemberNames @( $script:testUserPrincipal1 ) -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $Credential -eq $script:testCredential }
+                        }
                     }
                 }
 
-                Describe 'ConvertTo-Principal' {
+                Describe 'GroupResource\ConvertTo-Principal' {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
                     Mock -CommandName 'Split-MemberName' -MockWith { return $script:localDomain, $MemberName }
-                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
                     Mock -CommandName 'Get-PrincipalContext' -MockWith { return $script:testPrincipalContext }
                     Mock -CommandName 'Find-Principal' -MockWith {
                         switch ($IdentityValue)
@@ -1817,213 +2080,236 @@ try
                         }
                     }
 
-                    It 'Should return principal with local member name' {
-                        $convertToPrincipalResult = ConvertTo-Principal `
-                            -MemberName $script:testUserPrincipal1.Name `
-                            -PrincipalContextCache $principalContextCache `
-                            -Disposables $disposables
+                    Context 'When called with a local machine member that is not in the principal context cache' {
+                        It 'Should return principal with local member name' {
+                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                        $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
+                            $convertToPrincipalResult = ConvertTo-Principal `
+                                -MemberName $script:testUserPrincipal1.Name `
+                                -PrincipalContextCache $principalContextCache `
+                                -Disposables $disposables
 
-                        Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq $script:localDomain }
-                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $IdentityValue -eq $script:testUserPrincipal1.Name }
+                            $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
+
+                            Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq $script:localDomain }
+                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $IdentityValue -eq $script:testUserPrincipal1.Name }
+                        }
                     }
 
-                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                    Context 'When called with a domain member that is not in the principal context cache' {
+                        It 'Should attempt to resolve domain member with domain trust' {
+                            $convertToPrincipalResult = ConvertTo-Principal `
+                                -MemberName $script:testUserPrincipal1.Name `
+                                -PrincipalContextCache $principalContextCache `
+                                -Disposables $disposables
 
-                    It 'Should attempt to resolve non-local member with domain trust' {
-                        $convertToPrincipalResult = ConvertTo-Principal `
-                            -MemberName $script:testUserPrincipal1.Name `
-                            -PrincipalContextCache $principalContextCache `
-                            -Disposables $disposables
+                            $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
 
-                        $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
-
-                        Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq $script:localDomain }
-                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $IdentityValue -eq $script:testUserPrincipal1.Name }
+                            Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq $script:localDomain }
+                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $IdentityValue -eq $script:testUserPrincipal1.Name }
+                        }
                     }
 
-                    It 'Should pass Credential to appropriate functions' {
-                        $null = ConvertTo-Principal -MemberName $script:testUserPrincipal1.Name -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+                    Context 'When called with a domain member that is not in the principal context cache and a credential is passed' {
+                        It 'Should pass Credential to appropriate functions' {
+                            $null = ConvertTo-Principal -MemberName $script:testUserPrincipal1.Name -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential }
+                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential }
+                        }
                     }
 
-                    Mock -CommandName 'Find-Principal' -MockWith { }
+                    Context 'When called with a domain member that is not in the principal context cache and could not be found' {
+                        It 'Should throw if principal cannot be found' {
+                            Mock -CommandName 'Find-Principal' -MockWith { }
 
-                    It 'Should throw if principal cannot be found' {
-                        $errorMessage = ($script:localizedData.CouldNotFindPrincipal -f $script:testUserPrincipal1.Name)
+                            $errorMessage = ($script:localizedData.CouldNotFindPrincipal -f $script:testUserPrincipal1.Name)
 
-                        { $convertToPrincipalResult = ConvertTo-Principal `
-                            -MemberName $script:testUserPrincipal1.Name `
-                            -PrincipalContextCache $principalContextCache `
-                            -Disposables $disposables } | Should -Throw $errorMessage
+                            { $convertToPrincipalResult = ConvertTo-Principal `
+                                -MemberName $script:testUserPrincipal1.Name `
+                                -PrincipalContextCache $principalContextCache `
+                                -Disposables $disposables } | Should -Throw $errorMessage
+                        }
                     }
                 }
 
-                Describe 'Resolve-SidToPrincipal' {
-                    Mock -CommandName 'Find-Principal' -MockWith { }
-                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
-
+                Describe 'GroupResource\Resolve-SidToPrincipal' {
                     $testSidValue = 'S-1-0-0'
                     $testSid = New-Object -TypeName 'System.Security.Principal.SecurityIdentifier' -ArgumentList @( $testSidValue )
-
+                    $fakePrincipal = 'FakePrincipal'
                     $sidIdentityType = [System.DirectoryServices.AccountManagement.IdentityType]::Sid
 
-                    It 'Should throw when principal not found and scope is local' {
-                        { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
-
-                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
-                    }
-
+                    Mock -CommandName 'Find-Principal' -MockWith { }
                     Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
 
-                    It 'Should throw when principal not found and scope is custom' {
-                        $customDomain = 'CustomDomain'
+                    Context 'When called with a local principal that does not esxist' {
+                        It 'Should throw when principal not found' {
+                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                        { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $customDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
+                            { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
 
-                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
+                        }
                     }
 
-                    $fakePrincipal = 'FakePrincipal'
-                    Mock -CommandName 'Find-Principal' -MockWith { return $fakePrincipal }
+                    Context 'When called with a domain principal that does not exist' {
+                        It 'Should throw when principal not found' {
+                            $customDomain = 'CustomDomain'
 
-                    It 'Should return found principal' {
-                        Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain | Should -Be $fakePrincipal
-                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
+                            { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $customDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
+
+                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                        }
+                    }
+
+                    Context 'When called with a local principal that exists' {
+                        It 'Should return found principal' {
+                            Mock -CommandName 'Find-Principal' -MockWith { return $fakePrincipal }
+
+                            Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain | Should -Be $fakePrincipal
+                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
+                        }
                     }
                 }
 
-                Describe 'Get-PrincipalContext' {
+                Describe 'GroupResource\Get-PrincipalContext' {
                     $fakePrincipalContext = 'FakePrincipalContext'
 
-                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
                     Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -MockWith { $fakePrincipalContext }
 
                     $localMachineContext = [System.DirectoryServices.AccountManagement.ContextType]::Machine
                     $customDomainContext = [System.DirectoryServices.AccountManagement.ContextType]::Domain
 
-                    It 'Should create a new local principal context' {
-                        $principalContextCache = @{}
-                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                    Context 'When called with a local principal that does not exist in the principal context cache' {
+                        It 'Should create a new local principal context' {
+                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                        $localScope = 'localhost'
+                            $principalContextCache = @{}
+                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                        Get-PrincipalContext -Scope $localScope -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            $localScope = 'localhost'
 
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $localScope }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and $ArgumentList.Contains($localMachineContext) }
+                            Get-PrincipalContext -Scope $localScope -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        $principalContextCache.ContainsKey($localScope) | Should -Be $false
-                        $principalContextCache.$script:localDomain | Should -Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $localScope }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and $ArgumentList.Contains($localMachineContext) }
+
+                            $principalContextCache.ContainsKey($localScope) | Should -Be $false
+                            $principalContextCache.$script:localDomain | Should -Be $fakePrincipalContext
+                            $disposables.Contains($fakePrincipalContext) | Should -Be $true
+                        }
                     }
 
-                    It 'Should return the local principal context from the cache' {
-                        $principalContextCache = @{ $script:localDomain = $script:testPrincipalContext }
-                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                    Context 'When called with a domain principal that does exist in the principal context cache' {
+                        It 'Should return the local principal context from the cache' {
+                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                        Get-PrincipalContext -Scope $script:localDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            $principalContextCache = @{ $script:localDomain = $script:testPrincipalContext }
+                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
+                            Get-PrincipalContext -Scope $script:localDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        $principalContextCache.$script:localDomain | Should -Not -Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should -Be $false
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
+
+                            $principalContextCache.$script:localDomain | Should -Not -Be $fakePrincipalContext
+                            $disposables.Contains($fakePrincipalContext) | Should -Be $false
+                        }
                     }
 
-                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                    Context 'When called with a domain principal that does not exist in the principal cache and without a Credential' {
+                        It 'Should create a new domain principal context without a Credential' {
+                            $principalContextCache = @{}
+                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                    It 'Should create a new custom principal context without a Credential' {
-                        $principalContextCache = @{}
-                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                            $customDomain = 'CustomDomain'
 
-                        $customDomain = 'CustomDomain'
+                            Get-PrincipalContext -Scope $customDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        Get-PrincipalContext -Scope $customDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
 
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                            $principalContextArgumentList = @($customDomainContext, $customDomain)
 
-                        $principalContextArgumentList = @($customDomainContext, $customDomain)
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
+                                (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
-                            (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
-
-                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
+                            $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                            $disposables.Contains($fakePrincipalContext) | Should -Be $true
+                        }
                     }
 
-                    It 'Should create a new custom principal context with a Credential without a domain' {
-                        $principalContextCache = @{}
-                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                    Context 'When called with a domain principal that does not exist in the principal cache and with a Credential without a domain' {
+                        It 'Should create a new domain principal context with a credential without a domain' {
+                            $principalContextCache = @{}
+                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                        $customDomain = 'CustomDomain'
+                            $customDomain = 'CustomDomain'
 
-                        Get-PrincipalContext -Scope $customDomain -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            Get-PrincipalContext -Scope $customDomain -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
 
-                        $principalContextArgumentList = @( $customDomainContext, $customDomain, $script:testCredential.GetNetworkCredential().UserName, $script:testCredential.GetNetworkCredential().Password )
+                            $principalContextArgumentList = @( $customDomainContext, $customDomain, $script:testCredential.GetNetworkCredential().UserName, $script:testCredential.GetNetworkCredential().Password )
 
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
-                            (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
+                                (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
+                            $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                            $disposables.Contains($fakePrincipalContext) | Should -Be $true
+                        }
                     }
 
-                    It 'Should create a new custom principal context with a Credential with a domain' {
-                        $principalContextCache = @{}
-                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                    Context 'When called with a domain principal that does not exist in the principal cache and with a Credential with a domain' {
+                        It 'Should create a new custom principal context with a credential with a domain' {
+                            $principalContextCache = @{}
+                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                        $customDomain = 'CustomDomain'
+                            $customDomain = 'CustomDomain'
 
-                        $userNameWithDomain = 'CustomDomain\username'
-                        $testPassword = 'TestPassword'
-                        $secureTestPassword = ConvertTo-SecureString -String $testPassword -AsPlainText -Force
+                            $userNameWithDomain = 'CustomDomain\username'
+                            $testPassword = 'TestPassword'
+                            $secureTestPassword = ConvertTo-SecureString -String $testPassword -AsPlainText -Force
 
-                        $credentialWithDomain = New-Object -TypeName 'System.Management.Automation.PSCredential' -ArgumentList @( $userNameWithDomain, $secureTestPassword )
+                            $credentialWithDomain = New-Object -TypeName 'System.Management.Automation.PSCredential' -ArgumentList @( $userNameWithDomain, $secureTestPassword )
 
-                        Get-PrincipalContext -Scope $customDomain -Credential $credentialWithDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            Get-PrincipalContext -Scope $customDomain -Credential $credentialWithDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
 
-                        $principalContextArgumentList = @( $customDomainContext, $customDomain, $userNameWithDomain, $credentialWithDomain.GetNetworkCredential().Password  )
+                            $principalContextArgumentList = @( $customDomainContext, $customDomain, $userNameWithDomain, $credentialWithDomain.GetNetworkCredential().Password  )
 
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
-                            (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
+                                (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
+                            $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                            $disposables.Contains($fakePrincipalContext) | Should -Be $true
+                        }
                     }
 
-                    It 'Should return a custom principal context from the cache' {
-                        $customDomain = 'CustomDomain'
+                    Context 'When called with a domain principal that exists in the principal context cache' {
+                        It 'Should return a domain principal context from the cache' {
+                            $customDomain = 'CustomDomain'
 
-                        $principalContextCache = @{ $customDomain = $script:testPrincipalContext }
-                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                            $principalContextCache = @{ $customDomain = $script:testPrincipalContext }
+                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                        Get-PrincipalContext -Scope $customDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
+                            Get-PrincipalContext -Scope $customDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
-                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
+                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
 
-                        $principalContextCache.$customDomain | Should -Not -Be $fakePrincipalContext
-                        $disposables.Contains($fakePrincipalContext) | Should -Be $false
+                            $principalContextCache.$customDomain | Should -Not -Be $fakePrincipalContext
+                            $disposables.Contains($fakePrincipalContext) | Should -Be $false
+                        }
                     }
                 }
             }
         }
     }
-}
-finally
-{
-    Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
 }

--- a/Tests/Unit/MSFT_GroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_GroupResource.Tests.ps1
@@ -234,7 +234,7 @@ Describe 'GroupResource Unit Tests' {
             }
         }
 
-        Describe 'GroupResource\Assert-GroupNameValid' {
+        Describe 'GroupResource\Assert-GroupNameValid' -Tag 'Helper' {
             Context 'When called with an invalid group name' {
                 $invalidCharacters = @( '\', '/', '"', '[', ']', ':', '|', '<', '>', '+', '=', ';', ',', '?', '*', '@' ) |
                     ForEach-Object { @{ InvalidCharacter = $_ } }
@@ -290,7 +290,7 @@ Describe 'GroupResource Unit Tests' {
             }
         }
 
-        Describe 'GroupResource\Test-IsLocalMachine' {
+        Describe 'GroupResource\Test-IsLocalMachine' -Tag 'Helper' {
             BeforeEach {
                 Mock -CommandName 'Get-CimInstance' -MockWith { }
             }
@@ -338,7 +338,7 @@ Describe 'GroupResource Unit Tests' {
             }
         }
 
-        Describe 'GroupResource\Split-MemberName' {
+        Describe 'GroupResource\Split-MemberName' -Tag 'Helper' {
             Context 'When called with the MemberName in the domain\username format with the local scope' {
                 It 'Should return the local scope and the username' {
                     Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
@@ -412,7 +412,7 @@ Describe 'GroupResource Unit Tests' {
 
         if ($script:onNanoServer)
         {
-            Describe 'GroupResource\Get-TargetResourceOnNanoServer' {
+            Describe 'GroupResource\Get-TargetResourceOnNanoServer' -Tag 'Helper' {
                 $testMembers = @('User1', 'User2')
 
                 BeforeEach {
@@ -488,7 +488,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Set-TargetResourceOnNanoServer' {
+            Describe 'GroupResource\Set-TargetResourceOnNanoServer' -Tag 'Helper' {
                 <#
                     .SYNOPSIS
                         Assert that Group Members have not changed on Nano Server.
@@ -891,7 +891,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Test-TargetResourceOnNanoServer' {
+            Describe 'GroupResource\Test-TargetResourceOnNanoServer' -Tag 'Helper' {
                 BeforeEach {
                     Reset-TestGroup
 
@@ -1103,7 +1103,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Get-MembersOnNanoServer' {
+            Describe 'GroupResource\Get-MembersOnNanoServer' -Tag 'Helper' {
                 Context 'When called with a group that does not have any members' {
                     It 'Should return nothing' {
                         Mock -CommandName 'Get-LocalGroupMember' -MockWith { }
@@ -1139,7 +1139,7 @@ Describe 'GroupResource Unit Tests' {
         }
         else
         {
-            Describe 'GroupResource\Get-TargetResourceOnFullSKU' {
+            Describe 'GroupResource\Get-TargetResourceOnFullSKU' -Tag 'Helper' {
                 BeforeEach {
                     Reset-TestGroup
 
@@ -1209,7 +1209,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Set-TargetResourceOnFullSKU' {
+            Describe 'GroupResource\Set-TargetResourceOnFullSKU' -Tag 'Helper' {
                 <#
                     .SYNOPSIS
                         Assert that Group Members have not changed on Full SKU.
@@ -1735,7 +1735,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Test-TargetResourceOnFullSKU' {
+            Describe 'GroupResource\Test-TargetResourceOnFullSKU' -Tag 'Helper' {
                 BeforeEach {
                     Reset-TestGroup
 
@@ -2025,7 +2025,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Get-MembersOnFullSKU' {
+            Describe 'GroupResource\Get-MembersOnFullSKU' -Tag 'Helper' {
                 BeforeEach {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
@@ -2090,7 +2090,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Get-MembersAsPrincipalsList' {
+            Describe 'GroupResource\Get-MembersAsPrincipalsList' -Tag 'Helper' {
                 BeforeEach {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
@@ -2217,7 +2217,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\ConvertTo-UniquePrincipalsList' {
+            Describe 'GroupResource\ConvertTo-UniquePrincipalsList' -Tag 'Helper' {
                 BeforeEach {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
@@ -2281,7 +2281,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\ConvertTo-Principal' {
+            Describe 'GroupResource\ConvertTo-Principal' -Tag 'Helper' {
                 BeforeEach {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
@@ -2355,7 +2355,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Resolve-SidToPrincipal' {
+            Describe 'GroupResource\Resolve-SidToPrincipal' -Tag 'Helper' {
                 BeforeEach {
                     $testSidValue = 'S-1-0-0'
                     $testSid = New-Object -TypeName 'System.Security.Principal.SecurityIdentifier' -ArgumentList @( $testSidValue )

--- a/Tests/Unit/MSFT_GroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_GroupResource.Tests.ps1
@@ -89,6 +89,10 @@ Describe 'GroupResource Unit Tests' {
         <#
             .SYNOPSIS
                 Reset a test group object prior to running each test.
+
+            .DESCRIPTION
+                Resets the test group prior to executing tests to ensure
+                it is in a known state.
         #>
         function Reset-TestGroup {
             [CmdletBinding()]
@@ -485,6 +489,14 @@ Describe 'GroupResource Unit Tests' {
             }
 
             Describe 'GroupResource\Set-TargetResourceOnNanoServer' {
+                <#
+                    .SYNOPSIS
+                        Assert that Group Members have not changed on Nano Server.
+
+                    .DESCRIPTION
+                        This helper asserts that none of the calls to update a group
+                        have been made.
+                #>
                 function Assert-GroupMembersNotChangedOnNanoServer
                 {
                     [CmdletBinding()]
@@ -1198,6 +1210,14 @@ Describe 'GroupResource Unit Tests' {
             }
 
             Describe 'GroupResource\Set-TargetResourceOnFullSKU' {
+                <#
+                    .SYNOPSIS
+                        Assert that Group Members have not changed on Full SKU.
+
+                    .DESCRIPTION
+                        This helper asserts that none of the calls to update a group
+                        have been made.
+                #>
                 function Assert-GroupMembersNotChangedOnFullSKU
                 {
                     [CmdletBinding()]

--- a/Tests/Unit/MSFT_GroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_GroupResource.Tests.ps1
@@ -2398,7 +2398,7 @@ Describe 'GroupResource Unit Tests' {
                 }
             }
 
-            Describe 'GroupResource\Get-PrincipalContext' {
+            Describe 'GroupResource\Get-PrincipalContext' -Tag 'Helper' {
                 BeforeEach {
                     $fakePrincipalContext = 'FakePrincipalContext'
                     $localMachineContext = [System.DirectoryServices.AccountManagement.ContextType]::Machine

--- a/Tests/Unit/MSFT_GroupResource.Tests.ps1
+++ b/Tests/Unit/MSFT_GroupResource.Tests.ps1
@@ -16,1113 +16,1205 @@ Describe 'GroupResource Unit Tests' {
             -DscResourceModuleName 'PSDscResources' `
             -DscResourceName 'MSFT_GroupResource' `
             -TestType 'Unit'
+
+        InModuleScope 'MSFT_GroupResource' {
+            <#
+                Create test group object to be used in tests.
+                It must be created within module scope for objects to be
+                accessible to tests running in module scope.
+            #>
+            $script:disposableObjects = @()
+
+            $script:testGroupName = 'TestGroup'
+            $script:testGroupDescription = 'A group for testing'
+
+            $script:localDomain = $env:computerName
+
+            $script:onNanoServer = Test-IsNanoServer
+
+            $script:testMemberName1 = 'User1'
+            $script:testMemberName2 = 'User2'
+            $script:testMemberName3 = 'User3'
+
+            $testUserName = 'TestUserName'
+            $testPassword = 'TestPassword'
+            $secureTestPassword = ConvertTo-SecureString -String $testPassword -AsPlainText -Force
+
+            $script:testCredential = New-Object -TypeName 'System.Management.Automation.PSCredential' -ArgumentList @( $testUsername, $secureTestPassword )
+
+            $script:testErrorMessage = 'Test error message'
+
+            if ($script:onNanoServer)
+            {
+                $script:testLocalGroup = New-Object -TypeName 'Microsoft.PowerShell.Commands.LocalGroup' -ArgumentList @( $script:testGroupName )
+            }
+            else
+            {
+                $script:testPrincipalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Machine )
+
+                $script:testGroup = New-Object -TypeName 'System.DirectoryServices.AccountManagement.GroupPrincipal' -ArgumentList @( $script:testPrincipalContext )
+                $script:disposableObjects += $testGroup
+
+                $script:testUserPrincipal1 = New-Object -TypeName 'System.DirectoryServices.AccountManagement.UserPrincipal' -ArgumentList @( $testPrincipalContext )
+                $script:testuserPrincipal1.Name = $script:testMemberName1
+                $script:testuserPrincipal1.SamAccountName = 'SamAccountName1'
+                $script:disposableObjects += $script:testuserPrincipal1
+
+                $script:testUserPrincipal2 = New-Object -TypeName 'System.DirectoryServices.AccountManagement.UserPrincipal' -ArgumentList @( $testPrincipalContext )
+                $script:testuserPrincipal2.Name = $script:testMemberName2
+                $script:testuserPrincipal2.SamAccountName = 'SamAccountName2'
+                $script:disposableObjects += $script:testuserPrincipal2
+
+                $script:testUserPrincipal3 = New-Object -TypeName 'System.DirectoryServices.AccountManagement.UserPrincipal' -ArgumentList @( $testPrincipalContext )
+                $script:testuserPrincipal3.Name = $script:testMemberName3
+                $script:testuserPrincipal3.SamAccountName = 'SamAccountName3'
+                $script:disposableObjects += $script:testuserPrincipal3
+            }
+        }
     }
 
     AfterAll {
+        InModuleScope 'MSFT_GroupResource' {
+            # Dispose of module scoped test group objects
+            foreach ($disposableObject in $script:disposableObjects)
+            {
+                $disposableObject.Dispose()
+            }
+        }
+
         Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
     }
 
     InModuleScope 'MSFT_GroupResource' {
-        Describe 'All GroupResource Functions' {
-            BeforeAll {
-                $script:disposableObjects = @()
+        <#
+            .SYNOPSIS
+                Reset a test group object prior to running each test.
+        #>
+        function Reset-TestGroup {
+            [CmdletBinding()]
+            param
+            (
+            )
 
-                $script:testGroupName = 'TestGroup'
-                $script:testGroupDescription = 'A group for testing'
+            if (-not ($script:onNanoServer))
+            {
+                $script:testGroup.Name = $script:testGroupName
+                $script:testGroup.Description = ''
 
-                $script:localDomain = $env:computerName
-
-                $script:onNanoServer = Test-IsNanoServer
-
-                $script:testMemberName1 = 'User1'
-                $script:testMemberName2 = 'User2'
-                $script:testMemberName3 = 'User3'
-
-                $testUserName = 'TestUserName'
-                $testPassword = 'TestPassword'
-                $secureTestPassword = ConvertTo-SecureString -String $testPassword -AsPlainText -Force
-
-                $script:testCredential = New-Object -TypeName 'System.Management.Automation.PSCredential' -ArgumentList @( $testUsername, $secureTestPassword )
-
-                $script:testErrorMessage = 'Test error message'
-
-                if ($script:onNanoServer)
+                if ($script:testGroup.Members.Count -gt 0)
                 {
-                    $script:testLocalGroup = New-Object -TypeName 'Microsoft.PowerShell.Commands.LocalGroup' -ArgumentList @( $script:testGroupName )
-                }
-                else
-                {
-                    $script:testPrincipalContext = New-Object -TypeName 'System.DirectoryServices.AccountManagement.PrincipalContext' -ArgumentList @( [System.DirectoryServices.AccountManagement.ContextType]::Machine )
-
-                    $script:testGroup = New-Object -TypeName 'System.DirectoryServices.AccountManagement.GroupPrincipal' -ArgumentList @( $script:testPrincipalContext )
-                    $script:disposableObjects += $testGroup
-
-                    $script:testUserPrincipal1 = New-Object -TypeName 'System.DirectoryServices.AccountManagement.UserPrincipal' -ArgumentList @( $testPrincipalContext )
-                    $script:testuserPrincipal1.Name = $script:testMemberName1
-                    $script:testuserPrincipal1.SamAccountName = 'SamAccountName1'
-                    $script:disposableObjects += $script:testuserPrincipal1
-
-                    $script:testUserPrincipal2 = New-Object -TypeName 'System.DirectoryServices.AccountManagement.UserPrincipal' -ArgumentList @( $testPrincipalContext )
-                    $script:testuserPrincipal2.Name = $script:testMemberName2
-                    $script:testuserPrincipal2.SamAccountName = 'SamAccountName2'
-                    $script:disposableObjects += $script:testuserPrincipal2
-
-                    $script:testUserPrincipal3 = New-Object -TypeName 'System.DirectoryServices.AccountManagement.UserPrincipal' -ArgumentList @( $testPrincipalContext )
-                    $script:testuserPrincipal3.Name = $script:testMemberName3
-                    $script:testuserPrincipal3.SamAccountName = 'SamAccountName3'
-                    $script:disposableObjects += $script:testuserPrincipal3
+                    $script:testGroup.Members.Clear()
                 }
             }
+            else
+            {
+                # Reset the local group
+                $script:testLocalGroup.Name = $script:testGroupName
+                $script:testLocalGroup.Description = ''
+            }
+        }
 
+        <#
+            Get-Group, Add-GroupMember, Remove-GroupMember, Clear-GroupMembers, Save-Group,
+            Remove-Group, Find-Principal, and Remove-DisposableObject cannot be unit tested
+            because they are wrapper functions for .NET class function calls.
+        #>
+        Describe 'GroupResource\Get-TargetResource' -Tag 'Get' {
             BeforeEach {
-                # Reset the test group
-                if (-not ($script:onNanoServer))
-                {
-                    $script:testGroup.Name = $script:testGroupName
-                    $script:testGroup.Description = ''
-
-                    if ($script:testGroup.Members.Count -gt 0)
-                    {
-                        $script:testGroup.Members.Clear()
-                    }
-                }
-                else
-                {
-                    # Reset the local group
-                    $script:testLocalGroup.Name = $script:testGroupName
-                    $script:testLocalGroup.Description = ''
-                }
-            }
-
-            AfterAll {
-                foreach ($disposableObject in $script:disposableObjects)
-                {
-                    $disposableObject.Dispose()
-                }
-            }
-
-            <#
-                Get-Group, Add-GroupMember, Remove-GroupMember, Clear-GroupMembers, Save-Group,
-                Remove-Group, Find-Principal, and Remove-DisposableObject cannot be unit tested
-                because they are wrapper functions for .NET class function calls.
-            #>
-
-            Describe 'GroupResource\Get-TargetResource' -Tag 'Get' {
                 Mock -CommandName 'Assert-GroupNameValid' -MockWith { }
                 Mock -CommandName 'Test-IsNanoServer' -MockWith { return $false }
                 Mock -CommandName 'Get-TargetResourceOnFullSKU' -MockWith { return @{ TestResult = 'OnFullSKU' } }
                 Mock -CommandName 'Get-TargetResourceOnNanoServer' -MockWith { return @{ TestResult = 'OnNanoServer' } }
+            }
 
-                Context 'When called with the given group name' {
-                    It 'Should call Assert-GroupNameValid' {
-                        $null = Get-TargetResource -GroupName $script:testGroupName
+            Context 'When called with the given group name' {
+                It 'Should call Assert-GroupNameValid' {
+                    $null = Get-TargetResource -GroupName $script:testGroupName
 
-                        Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                    }
-                }
-
-                Context 'When called with all parameters when not on Nano Server' {
-                    It 'Should return output from Get-TargetResourceOnFullSKU' {
-                        $getTargetResourceResult = Get-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
-
-                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                        Assert-MockCalled -CommandName 'Get-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                        $getTargetResourceResult.TestResult | Should -Be 'OnFullSKU'
-                    }
-                }
-
-                Context 'When called with all parameters when on Nano Server' {
-                    It 'Should return output from Get-TargetResourceOnNanoServer' {
-                        Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
-
-                        $getTargetResourceResult = Get-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
-
-                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                        Assert-MockCalled -CommandName 'Get-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                        $getTargetResourceResult.TestResult | Should -Be 'OnNanoServer'
-                    }
+                    Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
                 }
             }
 
-            Describe 'GroupResource\Set-TargetResource' -Tag 'Set' {
+            Context 'When called with all parameters when not on Nano Server' {
+                It 'Should return output from Get-TargetResourceOnFullSKU' {
+                    $getTargetResourceResult = Get-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+
+                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                    Assert-MockCalled -CommandName 'Get-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                    $getTargetResourceResult.TestResult | Should -Be 'OnFullSKU'
+                }
+            }
+
+            Context 'When called with all parameters when on Nano Server' {
+                It 'Should return output from Get-TargetResourceOnNanoServer' {
+                    Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
+
+                    $getTargetResourceResult = Get-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+
+                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                    Assert-MockCalled -CommandName 'Get-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                    $getTargetResourceResult.TestResult | Should -Be 'OnNanoServer'
+                }
+            }
+        }
+
+        Describe 'GroupResource\Set-TargetResource' -Tag 'Set' {
+            BeforeEach {
                 Mock -CommandName 'Assert-GroupNameValid' -MockWith { }
                 Mock -CommandName 'Test-IsNanoServer' -MockWith { return $false }
                 Mock -CommandName 'Set-TargetResourceOnFullSKU' -MockWith { }
                 Mock -CommandName 'Set-TargetResourceOnNanoServer' -MockWith { }
+            }
 
-                Context 'When called with the given group name' {
-                    It 'Should call Assert-GroupNameValid' {
-                        $null = Set-TargetResource -GroupName $script:testGroupName
-                        Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                    }
-                }
-
-                Context 'When called with all parameters when not on Nano Server' {
-                    It 'Should call Set-TargetResourceOnFullSKU' {
-                        Set-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
-
-                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                        Assert-MockCalled -CommandName 'Set-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                    }
-                }
-
-                Context 'When called with all parameters when on Nano Server' {
-                    It 'Should call Set-TargetResourceOnNanoServer' {
-                        Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
-
-                        Set-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
-
-                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                        Assert-MockCalled -CommandName 'Set-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                    }
+            Context 'When called with the given group name' {
+                It 'Should call Assert-GroupNameValid' {
+                    $null = Set-TargetResource -GroupName $script:testGroupName
+                    Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
                 }
             }
 
-            Describe 'GroupResource\Test-TargetResource' -Tag 'Test' {
+            Context 'When called with all parameters when not on Nano Server' {
+                It 'Should call Set-TargetResourceOnFullSKU' {
+                    Set-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+
+                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                    Assert-MockCalled -CommandName 'Set-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                }
+            }
+
+            Context 'When called with all parameters when on Nano Server' {
+                It 'Should call Set-TargetResourceOnNanoServer' {
+                    Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
+
+                    Set-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+
+                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                    Assert-MockCalled -CommandName 'Set-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                }
+            }
+        }
+
+        Describe 'GroupResource\Test-TargetResource' -Tag 'Test' {
+            BeforeEach {
                 Mock -CommandName 'Assert-GroupNameValid' -MockWith { }
                 Mock -CommandName 'Test-IsNanoServer' -MockWith { return $false }
                 Mock -CommandName 'Test-TargetResourceOnFullSKU' -MockWith { }
                 Mock -CommandName 'Test-TargetResourceOnNanoServer' -MockWith { }
+            }
 
-                Context 'When called with the given group name' {
-                    It 'Should call Assert-GroupNameValid' {
-                        $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName
-                        Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                    }
-                }
-
-                Context 'When called with all parameters when not on Nano Server' {
-                    It 'Should call Test-TargetResourceOnFullSKU' {
-                        $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
-
-                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                        Assert-MockCalled -CommandName 'Test-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                    }
-                }
-
-                Context 'When called with all parameters when on Nano Server' {
-                    It 'Should call Test-TargetResourceOnNanoServer' {
-                        Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
-
-                        $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
-
-                        Assert-MockCalled -CommandName 'Test-IsNanoServer'
-                        Assert-MockCalled -CommandName 'Test-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
-                    }
+            Context 'When called with the given group name' {
+                It 'Should call Assert-GroupNameValid' {
+                    $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName
+                    Assert-MockCalled -CommandName 'Assert-GroupNameValid' -ParameterFilter { $GroupName -eq $script:testGroupName }
                 }
             }
 
-            Describe 'GroupResource\Assert-GroupNameValid' {
-                Context 'When called with an invalid group name' {
-                    $invalidCharacters = @( '\', '/', '"', '[', ']', ':', '|', '<', '>', '+', '=', ';', ',', '?', '*', '@' ) |
-                        ForEach-Object { @{ InvalidCharacter = $_ } }
+            Context 'When called with all parameters when not on Nano Server' {
+                It 'Should call Test-TargetResourceOnFullSKU' {
+                    $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
 
-                    It 'Should throw error if name contains invalid character "<InvalidCharacter>"' -TestCases $invalidCharacters {
-                        param
-                        (
-                            [Parameter(Mandatory = $true)]
-                            [System.String]
-                            $InvalidCharacter
-                        )
+                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                    Assert-MockCalled -CommandName 'Test-TargetResourceOnFullSKU' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                }
+            }
 
-                        $invalidGroupName = ('Invalid' + $invalidCharacter + 'Group')
-                        { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
-                    }
+            Context 'When called with all parameters when on Nano Server' {
+                It 'Should call Test-TargetResourceOnNanoServer' {
+                    Mock -CommandName 'Test-IsNanoServer' -MockWith { return $true }
 
-                    $invalidGroups = @(
-                        @{
-                            InvalidGroupName = '    '
-                            InvalidGroupDescription = 'only whitespace'
-                        },
-                        @{
-                            InvalidGroupName = '....'
-                            InvalidGroupDescription = 'only dots'
-                        },
-                        @{
-                            InvalidGroupName = '..    ..'
-                            InvalidGroupDescription = 'only whitespace and dots'
-                        }
+                    $testTargetResourceResult = Test-TargetResource -GroupName $script:testGroupName -Credential $script:testCredential
+
+                    Assert-MockCalled -CommandName 'Test-IsNanoServer'
+                    Assert-MockCalled -CommandName 'Test-TargetResourceOnNanoServer' -ParameterFilter { $GroupName -eq $script:testGroupName -and $Credential -eq $script:testCredential }
+                }
+            }
+        }
+
+        Describe 'GroupResource\Assert-GroupNameValid' {
+            Context 'When called with an invalid group name' {
+                $invalidCharacters = @( '\', '/', '"', '[', ']', ':', '|', '<', '>', '+', '=', ';', ',', '?', '*', '@' ) |
+                    ForEach-Object { @{ InvalidCharacter = $_ } }
+
+                It 'Should throw error if name contains invalid character "<InvalidCharacter>"' -TestCases $invalidCharacters {
+                    param
+                    (
+                        [Parameter(Mandatory = $true)]
+                        [System.String]
+                        $InvalidCharacter
                     )
 
-                    It 'Should throw if name contains <InvalidGroupDescription>' -TestCases $invalidGroups {
-                        param
-                        (
-                            [Parameter(Mandatory = $true)]
-                            [System.String]
-                            $InvalidGroupDescription,
-
-                            [Parameter(Mandatory = $true)]
-                            [System.String]
-                            $InvalidGroupName
-                        )
-
-                        { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
-                    }
+                    $invalidGroupName = ('Invalid' + $invalidCharacter + 'Group')
+                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
                 }
 
-                Context 'When called with a valid group name' {
-                    It 'Should not throw if name contains whitespace and dots' {
-                        $invalidGroupName = '..  MyGroup  ..'
-                        { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Not -Throw
+                $invalidGroups = @(
+                    @{
+                        InvalidGroupName = '    '
+                        InvalidGroupDescription = 'only whitespace'
+                    },
+                    @{
+                        InvalidGroupName = '....'
+                        InvalidGroupDescription = 'only dots'
+                    },
+                    @{
+                        InvalidGroupName = '..    ..'
+                        InvalidGroupDescription = 'only whitespace and dots'
                     }
+                )
+
+                It 'Should throw if name contains <InvalidGroupDescription>' -TestCases $invalidGroups {
+                    param
+                    (
+                        [Parameter(Mandatory = $true)]
+                        [System.String]
+                        $InvalidGroupDescription,
+
+                        [Parameter(Mandatory = $true)]
+                        [System.String]
+                        $InvalidGroupName
+                    )
+
+                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Throw ($script:localizedData.InvalidGroupName -f $invalidGroupName, '')
                 }
             }
 
-            Describe 'GroupResource\Test-IsLocalMachine' {
+            Context 'When called with a valid group name' {
+                It 'Should not throw if name contains whitespace and dots' {
+                    $invalidGroupName = '..  MyGroup  ..'
+                    { Assert-GroupNameValid -GroupName $invalidGroupName } | Should -Not -Throw
+                }
+            }
+        }
+
+        Describe 'GroupResource\Test-IsLocalMachine' {
+            BeforeEach {
                 Mock -CommandName 'Get-CimInstance' -MockWith { }
+            }
 
-                Context 'When called with a scope name that resolves to the local machine' {
-                    $localMachineScopes = @(
-                        @{ localMachineScope = '.' }
-                        @{ localMachineScope = $ENV:COMPUTERNAME }
-                        @{ localMachineScope = 'localhost' }
-                        @{ localMachineScope = '127.0.0.1' }
+            Context 'When called with a scope name that resolves to the local machine' {
+                $localMachineScopes = @(
+                    @{ localMachineScope = '.' }
+                    @{ localMachineScope = $ENV:COMPUTERNAME }
+                    @{ localMachineScope = 'localhost' }
+                    @{ localMachineScope = '127.0.0.1' }
+                )
+
+                It 'Should return true for local machine scope "<LocalMachineScope>"' -TestCases $localMachineScopes {
+                    param
+                    (
+                        [Parameter(Mandatory = $true)]
+                        [System.String]
+                        $LocalMachineScope
                     )
 
-                    It 'Should return true for local machine scope "<LocalMachineScope>"' -TestCases $localMachineScopes {
-                        param
-                        (
-                            [Parameter(Mandatory = $true)]
-                            [System.String]
-                            $LocalMachineScope
-                        )
+                    Test-IsLocalMachine -Scope $LocalMachineScope | Should -Be $true
+                }
 
-                        Test-IsLocalMachine -Scope $LocalMachineScope | Should -Be $true
-                    }
+                $customLocalIPAddress = '123.4.5.6'
 
-                    $customLocalIPAddress = '123.4.5.6'
+                It 'Should return true if custom local IP address provided and Get-CimInstance contains matching IP address' {
+                    Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @($customLocalIPAddress, '789.1.2.3')} }
 
-                    It 'Should return true if custom local IP address provided and Get-CimInstance contains matching IP address' {
-                        Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @($customLocalIPAddress, '789.1.2.3')} }
+                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $true
+                }
+            }
 
-                        Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $true
+            Context 'When called with a scope name that does not resolve to the local machine' {
+                $customLocalIPAddress = '123.4.5.6'
+
+                It 'Should return false if custom local IP address provided and Get-CimInstance returns null' {
+                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
+                }
+
+                It 'Should return false if custom local IP address provided and Get-CimInstance do not contain matching IP addresses' {
+                    Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @('789.1.2.3')} }
+
+                    Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
+                }
+            }
+        }
+
+        Describe 'GroupResource\Split-MemberName' {
+            Context 'When called with the MemberName in the domain\username format with the local scope' {
+                It 'Should return the local scope and the username' {
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
+
+                    $testMemberName = 'domain\username'
+                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                    Assert-MockCalled -CommandName 'Test-IsLocalMachine'
+
+                    $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
+                }
+            }
+
+            Context 'When called with a MemberName in the domain\username format with the domain scope' {
+                It 'Should return the specified domain and the username' {
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+
+                    $testMemberName = 'domain\username'
+                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                    Assert-MockCalled -CommandName 'Test-IsLocalMachine'
+
+                    $splitMemberNameResult | Should -Be @( 'domain', 'username' )
+                }
+            }
+
+            Context 'When called with a MemberName in the username@domain format with the domain scope' {
+                It 'Should return the specified domain and the username' {
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+
+                    $testMemberName = 'username@domain'
+                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                    $splitMemberNameResult | Should -Be @( 'domain', 'username' )
+                }
+            }
+
+            Context 'When called with a MemberName in the CN=username,DC=domain format with local scope' {
+                It 'Should return the local scope and the username' {
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+
+                    $testMemberName = 'CN=username,DC=domain'
+                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                    $splitMemberNameResult | Should -Be @( $script:localDomain, $testMemberName )
+                }
+            }
+
+            Context 'When called with a MemberName in the CN=username,DC=domain format with domain scope' {
+                It 'Should return the specified domain and the username' {
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+
+                    $testMemberName = 'CN=username,DC=domain,DC=com'
+                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                    $splitMemberNameResult | Should -Be @( 'domain', $testMemberName )
+                }
+            }
+
+            Context 'When called with a MemberName in the without a scope specified' {
+                It 'Should return the local scope and the username' {
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+
+                    $testMemberName = 'username'
+                    $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
+
+                    $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
+                }
+            }
+        }
+
+        if ($script:onNanoServer)
+        {
+            Describe 'GroupResource\Get-TargetResourceOnNanoServer' {
+                $testMembers = @('User1', 'User2')
+
+                BeforeEach {
+                    Reset-TestGroup
+
+                    Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @() }
+                }
+
+                Context 'When Get-LocalGroup throws a GroupNotFound exception' {
+                    It 'Should return Ensure as Absent' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+
+                        $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 2
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Absent'
                     }
                 }
 
-                Context 'When called with a scope name that does not resolve to the local machine' {
-                    $customLocalIPAddress = '123.4.5.6'
+                Context 'When Get-LocalGroup throws an exception other than GroupNotFound' {
+                    It 'Should throw expected exception' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
-                    It 'Should return false if custom local IP address provided and Get-CimInstance returns null' {
-                        Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
+                        { $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName } | Should -Throw $script:testErrorMessage
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
                     }
+                }
 
-                    It 'Should return false if custom local IP address provided and Get-CimInstance do not contain matching IP addresses' {
-                        Mock -CommandName 'Get-CimInstance' -MockWith { return @{ IPAddress = @('789.1.2.3')} }
+                Context 'When Get-LocalGroup returns a valid, existing group without members' {
+                    It 'Should return expected values and call expected mocks' {
+                        $script:testLocalGroup.Description = $script:testGroupDescription
 
-                        Test-IsLocalMachine -Scope $customLocalIPAddress | Should -Be $false
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+
+                        $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
+
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $null
+                    }
+                }
+
+                Context 'When Get-LocalGroup returns a valid, existing group with members' {
+                    It 'Should return expected values and call expected mocks' {
+                        $script:testLocalGroup.Description = $script:testGroupDescription
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return $testMembers }
+
+                        $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
+
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $testMembers
                     }
                 }
             }
 
-            Describe 'GroupResource\Split-MemberName' {
-                Context 'When called with the MemberName in the domain\username format with the local scope' {
-                    It 'Should return the local scope and the username' {
-                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
+            Describe 'GroupResource\Set-TargetResourceOnNanoServer' {
+                function Assert-GroupMembersNotChangedOnNanoServer
+                {
+                    [CmdletBinding()]
+                    param
+                    (
+                    )
 
-                        $testMemberName = 'domain\username'
-                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
-
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine'
-
-                        $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
-                    }
+                    Assert-MockCalled -CommandName 'Set-LocalGroup' -Times 0 -Scope 'It'
+                    Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
+                    Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
                 }
 
-                Context 'When called with a MemberName in the domain\username format with the domain scope' {
-                    It 'Should return the specified domain and the username' {
-                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                BeforeEach {
+                    Reset-TestGroup
 
-                        $testMemberName = 'domain\username'
-                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
-
-                        Assert-MockCalled -CommandName 'Test-IsLocalMachine'
-
-                        $splitMemberNameResult | Should -Be @( 'domain', 'username' )
-                    }
-                }
-
-                Context 'When called with a MemberName in the username@domain format with the domain scope' {
-                    It 'Should return the specified domain and the username' {
-                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
-
-                        $testMemberName = 'username@domain'
-                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
-
-                        $splitMemberNameResult | Should -Be @( 'domain', 'username' )
-                    }
-                }
-
-                Context 'When called with a MemberName in the CN=username,DC=domain format with local scope' {
-                    It 'Should return the local scope and the username' {
-                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
-
-                        $testMemberName = 'CN=username,DC=domain'
-                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
-
-                        $splitMemberNameResult | Should -Be @( $script:localDomain, $testMemberName )
-                    }
-                }
-
-                Context 'When called with a MemberName in the CN=username,DC=domain format with domain scope' {
-                    It 'Should return the specified domain and the username' {
-                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
-
-                        $testMemberName = 'CN=username,DC=domain,DC=com'
-                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
-
-                        $splitMemberNameResult | Should -Be @( 'domain', $testMemberName )
-                    }
-                }
-
-                Context 'When called with a MemberName in the without a scope specified' {
-                    It 'Should return the local scope and the username' {
-                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
-
-                        $testMemberName = 'username'
-                        $splitMemberNameResult = Split-MemberName -MemberName $testMemberName
-
-                        $splitMemberNameResult | Should -Be @( $script:localDomain, 'username' )
-                    }
-                }
-            }
-
-            if ($script:onNanoServer)
-            {
-                Describe 'GroupResource\Get-TargetResourceOnNanoServer' {
-                    $testMembers = @('User1', 'User2')
-
-                    BeforeEach {
-                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @() }
-                    }
-
-                    Context 'When Get-LocalGroup throws a GroupNotFound exception' {
-                        It 'Should return Ensure as Absent' {
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
-
-                            $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-
-                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                            $getTargetResourceResult.Keys.Count | Should -Be 2
-                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                            $getTargetResourceResult.Ensure | Should -Be 'Absent'
-                        }
-                    }
-
-                    Context 'When Get-LocalGroup throws an exception other than GroupNotFound' {
-                        It 'Should throw expected exception' {
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
-
-                            { $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName } | Should -Throw $script:testErrorMessage
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        }
-                    }
-
-                    Context 'When Get-LocalGroup returns a valid, existing group without members' {
-                        It 'Should return expected values and call expected mocks' {
-                            $script:testLocalGroup.Description = $script:testGroupDescription
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-
-                            $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
-
-                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                            $getTargetResourceResult.Keys.Count | Should -Be 4
-                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                            $getTargetResourceResult.Ensure | Should -Be 'Present'
-                            $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                            $getTargetResourceResult.Members | Should -Be $null
-                        }
-                    }
-
-                    Context 'When Get-LocalGroup returns a valid, existing group with members' {
-                        It 'Should return expected values and call expected mocks' {
-                            $script:testLocalGroup.Description = $script:testGroupDescription
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return $testMembers }
-
-                            $getTargetResourceResult = Get-TargetResourceOnNanoServer -GroupName $script:testGroupName
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group -eq $script:testLocalGroup }
-
-                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                            $getTargetResourceResult.Keys.Count | Should -Be 4
-                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                            $getTargetResourceResult.Ensure | Should -Be 'Present'
-                            $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                            $getTargetResourceResult.Members | Should -Be $testMembers
-                        }
-                    }
-                }
-
-                Describe 'GroupResource\Set-TargetResourceOnNanoServer' {
-                    Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+                    Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
                     Mock -CommandName 'New-LocalGroup' -MockWith { return $script:testLocalGroup }
                     Mock -CommandName 'Set-LocalGroup' -MockWith { }
                     Mock -CommandName 'Remove-LocalGroup' -MockWith { }
                     Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { }
                     Mock -CommandName 'Add-LocalGroupMember' -MockWith { }
                     Mock -CommandName 'Remove-LocalGroupMember' -MockWith { }
+                }
 
-                    function Assert-GroupMembersNotChangedOnNanoServer
-                    {
-                        [CmdletBinding()]
-                        param
-                        (
-                        )
+                Context 'When Ensure is absent and the group does not exist' {
+                    It 'Should not attempt to remove an absent group' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
 
-                        Assert-MockCalled -CommandName 'Set-LocalGroup' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -Times 0 -Scope 'It'
-                    }
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent'
 
-                    Context 'When Ensure is absent and the group does not exist' {
-                        It 'Should not attempt to remove an absent group' {
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-LocalGroup' -Times 0 -Scope 'It'
-                        }
-                    }
-
-                    Context 'When Ensure is absent and the group exists' {
-                        It 'Should remove an existing group' {
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName } -Scope 'It'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist' {
-                        It 'Should create an empty group' {
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and Description is passed' {
-                        It 'Should create an empty group with a description' {
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Set-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName -and $Description -eq $script:testGroupDescription }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and Members is passed with one local member' {
-                        It 'Should create a group with one local member' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and Members is passed with two local members' {
-                        It 'Should create a group with two local members' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with one local member' {
-                        It 'Should create a group with one local member' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with two local members' {
-                        It 'Should create a group with two local members using MembersToInclude' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Get-LocalGroup throws an exception other than GroupNotFound' {
-                        It 'Should throw expected exception' {
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
-
-                            { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and Members is passed with one member' {
-                        It 'Should add a member to an existing group' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with one member missing from Members list passed' {
-                        It 'Should add a member to an existing group' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and MembersToInclude is passed with one member' {
-                        It 'Should add a member to an existing group' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with two members missing from MembersToInclude list passed' {
-                        It 'Should add two members to an existing group' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with one member not in the Members list passed' {
-                        It 'Should remove a member from an existing group' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with containing members and an empty Members list passed' {
-                        It 'Should clear all members from an existing group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
-                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with a member contained in the MembersToExclude list passed' {
-                        It 'Should remove a member from an existing group' {
-                            $testMembers = @( $script:testMemberName2 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with Members passed that require one member to be added and one removed' {
-                        It 'Should add a user and remove a user' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName3 }
-                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with MembersToInclude and MembersToExclude passed that require one member to be added and one removed' {
-                        It 'Should add a user and remove a user' {
-                            $testMembersToInclude = @( $script:testMemberName3 )
-                            $testMembersToExclude = @( $script:testMemberName2 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMemberstoInclude -MembersToExclude $testMemberstoExclude -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName3 }
-                            Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
-                        }
-                    }
-
-                    Context 'When Members and MembersToInclude are both specified' {
-                        It 'Should throw expected exception' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-                            $testMembersToInclude = @( $script:testMemberName3 )
-
-                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-                    }
-
-                    Context 'When Members and MembersToExclude are both specified' {
-                        It 'Should throw expected exception' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-                            $testMembersToExclude = @( $script:testMemberName3 )
-
-                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-                    }
-
-                    Context 'When MembersToInclude and MembersToExclude both contain the same member' {
-                        It 'Should throw expected exception' {
-                            $testMembersToInclude = @( $script:testMemberName1 )
-                            $testMembersToExclude = @( $script:testMemberName1 )
-
-                            $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with members already containing all principals in the MembersToInclude' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnNanoServer
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with members not containing any of the principals in the MembersToExclude' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( $script:testMemberName3 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnNanoServer
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with members that match the Members' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnNanoServer
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and the MembersToInclude is specified but Empty' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnNanoServer
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and the MembersToExclude is specified but Empty' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnNanoServer
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and both MembersToInclude and MembersToExclude are empty' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -MembersToExclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnNanoServer
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and empty Members passed' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnNanoServer
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and no changes are made to the group' {
-                        It 'Should not save group' {
-                            Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-                            Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                            Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnNanoServer
-                        }
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-LocalGroup' -Times 0 -Scope 'It'
                     }
                 }
 
-                Describe 'GroupResource\Test-TargetResourceOnNanoServer' {
-                    Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
-                    Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { }
+                Context 'When Ensure is absent and the group exists' {
+                    It 'Should remove an existing group' {
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent'
 
-                    Context 'When called with Ensure is Absent' {
-                        It 'Should return true for an absent group' {
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return false for an existing group when Ensure is Absent' {
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        }
-
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName } -Scope 'It'
                     }
+                }
 
-                    Context 'When called with Ensure is Present' {
-                        It 'Should return false for an absent group when Ensure is Present' {
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
+                Context 'When Ensure is present and the group does not exist' {
+                    It 'Should create an empty group' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
 
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        }
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present'
 
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and Description is passed' {
+                    It 'Should create an empty group with a description' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Set-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName -and $Description -eq $script:testGroupDescription }
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and Members is passed with one local member' {
+                    It 'Should create a group with one local member' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and Members is passed with two local members' {
+                    It 'Should create a group with two local members' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with one local member' {
+                    It 'Should create a group with one local member' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with two local members' {
+                    It 'Should create a group with two local members using MembersToInclude' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
+
+                Context 'When Get-LocalGroup throws an exception other than GroupNotFound' {
+                    It 'Should throw expected exception' {
                         Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
 
-                        It 'Should throw from group retrieval if exception is not a GroupNotFoundException' {
-                            { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
-                        }
-
-                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
-
-                        It 'Should return true for an existing group when Ensure is Present' {
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return true for an existing group with a matching description' {
-                            $script:testLocalGroup.Description = $script:testGroupDescription
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return false for an existing  group with a mismatching description' {
-                            $script:testLocalGroup.Description = $script:testGroupDescription
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return true with matching empty members when using Members' {
-                            $testMembers = @( )
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return false with mismatching number of members when using Members' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return false with missing member when using MembersToInclude' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return true with missing member when using MembersToExclude' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-
-                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
-
-                        It 'Should return false when group contains member specified by MemberstoExclude' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return true when group contains member specified by MembersToInclude' {
-                            $testMembers = @( $script:testMemberName1 )
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return true when group members match Members' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should return false when group members do not match Members' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
-
-                            Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-
-                        It 'Should throw if Members and MembersToInclude are both specified' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-                            $testMembersToInclude = @( $script:testMemberName3 )
-
-                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
-
-                            { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-
-                        It 'Should throw if Members and MembersToExclude are both specified' {
-                            $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
-                            $testMembersToExclude = @( $script:testMemberName3 )
-
-                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
-
-                            { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-
-                        It 'Should throw if MembersToInclude and MembersToExclude contain the same member' {
-                            $testMembersToInclude = @( $script:testMemberName1 )
-                            $testMembersToExclude = @( $script:testMemberName1 )
-
-                            $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
-
-                            { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
                     }
                 }
 
-                Describe 'GroupResource\Get-MembersOnNanoServer' {
-                    Context 'When called with a group that does not have any members' {
-                        It 'Should return nothing' {
-                            Mock -CommandName 'Get-LocalGroupMember' -MockWith { }
+                Context 'When Ensure is present and the group exists with no members and Members is passed with one member' {
+                    It 'Should add a member to an existing group' {
+                        $testMembers = @( $script:testMemberName1 )
 
-                            Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be $null
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                            Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
                     }
+                }
 
-                    Context 'When called with a group that has local and domain members' {
-                        It 'Should return all local members and no domain members' {
-                            $testDomainUser1 = @{
-                                Name = 'TestDomainUser1'
-                                PrincipalSource = 'NotLocal'
-                            }
+                Context 'When Ensure is present and the group exists with two members missing from Members list passed' {
+                    It 'Should add two members to an existing group' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
 
-                            $testDomainUser2 = @{
-                                Name = 'TestDomainUser2'
-                                PrincipalSource = 'Local'
-                            }
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
 
-                            Mock -CommandName 'Get-LocalGroupMember' -MockWith { return @( $testDomainUser1, $testDomainUser2 ) }
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
 
-                            Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be @( $testDomainUser2.Name )
+                Context 'When Ensure is present and the group exists with no members and MembersToInclude is passed with one member' {
+                    It 'Should add a member to an existing group' {
+                        $testMembers = @( $script:testMemberName1 )
 
-                            Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with two members missing from MembersToInclude list passed' {
+                    It 'Should add two members to an existing group' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with one member not in the Members list passed' {
+                    It 'Should remove a member from an existing group' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with containing members and an empty Members list passed' {
+                    It 'Should clear all members from an existing group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName1 }
+                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with a member contained in the MembersToExclude list passed' {
+                    It 'Should remove a member from an existing group' {
+                        $testMembers = @( $script:testMemberName2 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with Members passed that require one member to be added and one removed' {
+                    It 'Should add a user and remove a user' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName3 }
+                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with MembersToInclude and MembersToExclude passed that require one member to be added and one removed' {
+                    It 'Should add a user and remove a user' {
+                        $testMembersToInclude = @( $script:testMemberName3 )
+                        $testMembersToExclude = @( $script:testMemberName2 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMemberstoInclude -MembersToExclude $testMemberstoExclude -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Add-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName3 }
+                        Assert-MockCalled -CommandName 'Remove-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Member.Name -eq $script:testMemberName2 }
+                    }
+                }
+
+                Context 'When Members and MembersToInclude are both specified' {
+                    It 'Should throw expected exception' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        $testMembersToInclude = @( $script:testMemberName3 )
+
+                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When Members and MembersToExclude are both specified' {
+                    It 'Should throw expected exception' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        $testMembersToExclude = @( $script:testMemberName3 )
+
+                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When MembersToInclude and MembersToExclude both contain the same member' {
+                    It 'Should throw expected exception' {
+                        $testMembersToInclude = @( $script:testMemberName1 )
+                        $testMembersToExclude = @( $script:testMemberName1 )
+
+                        $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        { Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with members already containing all principals in the MembersToInclude' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnNanoServer
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with members not containing any of the principals in the MembersToExclude' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( $script:testMemberName3 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnNanoServer
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with members that match the Members' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnNanoServer
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and the MembersToInclude is specified but Empty' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnNanoServer
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and the MembersToExclude is specified but Empty' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnNanoServer
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and both MembersToInclude and MembersToExclude are empty' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -MembersToExclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnNanoServer
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and empty Members passed' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( )
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnNanoServer
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and no changes are made to the group' {
+                    It 'Should not save group' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { return @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Set-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnNanoServer
                     }
                 }
             }
-            else
-            {
-                Describe 'GroupResource\Get-TargetResourceOnFullSKU' {
+
+            Describe 'GroupResource\Test-TargetResourceOnNanoServer' {
+                BeforeEach {
+                    Reset-TestGroup
+
+                    Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                    Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { }
+                }
+
+                Context 'When Ensure is absent and the group does not exist' {
+                    It 'Should return true and expected mocks are called' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is absent and the group exists' {
+                    It 'Should return false and expected mocks are called' {
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist' {
+                    It 'Should return false and expected mocks are called' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message 'Test error message' -CategoryReason 'GroupNotFoundException' }
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Get-LocalGroup throws an exception other than GroupNotFound' {
+                    It 'Should throw expected exception' {
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { Write-Error -Message $script:testErrorMessage -CategoryReason 'OtherException' }
+
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' } | Should -Throw $script:testErrorMessage
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists' {
+                    It 'Should return true and expected mocks are called' {
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and Description matches' {
+                    It 'Should return true and expected mocks are called' {
+                        $script:testLocalGroup.Description = $script:testGroupDescription
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and Description does not match' {
+                    It 'Should return false and expected mocks are called' {
+                        $script:testLocalGroup.Description = $script:testGroupDescription
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and with no members and Members should be empty' {
+                    It 'Should return true and expected mocks are called' {
+                        $testMembers = @( )
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists mismatching number of members when passing Members' {
+                    It 'Should return false and expected mocks are called' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with missing member when passing MembersToInclude' {
+                    It 'Should return false and expected mocks are called' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with missing member when passing MembersToExclude' {
+                    It 'Should return true and expected mocks are called' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists containing member specified by MembersToExclude' {
+                    It 'Should return false and expected mocks are called' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists containing member specified by MembersToInclude' {
+                    It 'Should return true and expected mocks are called' {
+                        $testMembers = @( $script:testMemberName1 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and current members matches Members' {
+                    It 'Should return true and expected mocks are called' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and current members do not match Members' {
+                    It 'Should return false and expected mocks are called' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName3 )
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroup' -ParameterFilter { $Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnNanoServer' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When Members and MembersToInclude are both specified' {
+                    It 'Should throw expected exception' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        $testMembersToInclude = @( $script:testMemberName3 )
+
+                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When Members and MembersToExclude are both specified' {
+                    It 'Should throw expected exception' {
+                        $testMembers = @( $script:testMemberName1, $script:testMemberName2 )
+                        $testMembersToExclude = @( $script:testMemberName3 )
+
+                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When MembersToInclude and MembersToExclude both contain the same member' {
+                    It 'Should throw expected exception' {
+                        $testMembersToInclude = @( $script:testMemberName1 )
+                        $testMembersToExclude = @( $script:testMemberName1 )
+
+                        $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testMemberName1, 'MembersToInclude', 'MembersToExclude'
+
+                        Mock -CommandName 'Get-LocalGroup' -MockWith { return $script:testLocalGroup }
+                        Mock -CommandName 'Get-MembersOnNanoServer' -MockWith { @( $script:testMemberName1, $script:testMemberName2 ) }
+
+                        { Test-TargetResourceOnNanoServer -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+            }
+
+            Describe 'GroupResource\Get-MembersOnNanoServer' {
+                Context 'When called with a group that does not have any members' {
+                    It 'Should return nothing' {
+                        Mock -CommandName 'Get-LocalGroupMember' -MockWith { }
+
+                        Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be $null
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When called with a group that has local and domain members' {
+                    It 'Should return all local members without domain prefix and domain members with domain prefix' {
+                        $testGroupMember1 = @{
+                            Name = 'Domain\TestDomainUser1'
+                            PrincipalSource = 'NotLocal'
+                            ExpectedName = 'Domain\TestDomainUser1'
+                        }
+
+                        $testGroupMember2 = @{
+                            Name = 'LocalMachine\TestLocalUser2'
+                            PrincipalSource = 'Local'
+                            ExpectedName = 'TestLocalUser2'
+                        }
+
+                        Mock -CommandName 'Get-LocalGroupMember' -MockWith { return @( $testGroupMember1, $testGroupMember2 ) }
+
+                        Get-MembersOnNanoServer -Group $script:testLocalGroup | Should -Be @( $testGroupMember1.ExpectedName, $testGroupMember2.ExpectedName )
+
+                        Assert-MockCalled -CommandName 'Get-LocalGroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+            }
+        }
+        else
+        {
+            Describe 'GroupResource\Get-TargetResourceOnFullSKU' {
+                BeforeEach {
+                    Reset-TestGroup
+
                     $testMembers = @($script:testuserPrincipal1.Name, $script:testuserPrincipal2.Name)
 
                     Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return @() }
                     Mock -CommandName 'Remove-DisposableObject' -MockWith { }
+                }
 
-                    Context 'When called with a Group that does not exist' {
-                        It 'Should return expected values and call expected mocks' {
-                            Mock -CommandName 'Get-Group' -MockWith { }
+                Context 'When called with a Group that does not exist' {
+                    It 'Should return expected values and call expected mocks' {
+                        Mock -CommandName 'Get-Group' -MockWith { }
 
-                            $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
+                        $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
 
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
 
-                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                            $getTargetResourceResult.Keys.Count | Should -Be 2
-                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                            $getTargetResourceResult.Ensure | Should -Be 'Absent'
-                        }
-                    }
-
-                    Context 'When called with a valid, existing Group containing no members' {
-                        It 'Should return expected values and call expected mocks' {
-                            $script:testGroup.Description = $script:testGroupDescription
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
-
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-
-                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                            $getTargetResourceResult.Keys.Count | Should -Be 4
-                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                            $getTargetResourceResult.Ensure | Should -Be 'Present'
-                            $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                            $getTargetResourceResult.Members | Should -Be $null
-                        }
-                    }
-
-                    Context 'When called with a valid, existing Group with containing members' {
-                        It 'Should return expected values and call expected mocks' {
-                            $testGroup.Description = $script:testGroupDescription
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-                            Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return $testMembers }
-
-                            $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
-
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-
-                            $getTargetResourceResult -is [Hashtable] | Should -Be $true
-                            $getTargetResourceResult.Keys.Count | Should -Be 4
-                            $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
-                            $getTargetResourceResult.Ensure | Should -Be 'Present'
-                            $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
-                            $getTargetResourceResult.Members | Should -Be $testMembers
-                        }
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 2
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Absent'
                     }
                 }
 
-                Describe 'GroupResource\Set-TargetResourceOnFullSKU' {
+                Context 'When called with a valid, existing Group containing no members' {
+                    It 'Should return expected values and call expected mocks' {
+                        $script:testGroup.Description = $script:testGroupDescription
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
+
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $null
+                    }
+                }
+
+                Context 'When called with a valid, existing Group with containing members' {
+                    It 'Should return expected values and call expected mocks' {
+                        $testGroup.Description = $script:testGroupDescription
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+                        Mock -CommandName 'Get-MembersOnFullSKU' -MockWith { return $testMembers }
+
+                        $getTargetResourceResult = Get-TargetResourceOnFullSKU -GroupName $script:testGroupName
+
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersOnFullSKU' -ParameterFilter { $Group -eq $script:testGroup }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+
+                        $getTargetResourceResult -is [Hashtable] | Should -Be $true
+                        $getTargetResourceResult.Keys.Count | Should -Be 4
+                        $getTargetResourceResult.GroupName | Should -Be $script:testGroupName
+                        $getTargetResourceResult.Ensure | Should -Be 'Present'
+                        $getTargetResourceResult.Description | Should -Be $script:testGroupDescription
+                        $getTargetResourceResult.Members | Should -Be $testMembers
+                    }
+                }
+            }
+
+            Describe 'GroupResource\Set-TargetResourceOnFullSKU' {
+                function Assert-GroupMembersNotChangedOnFullSKU
+                {
+                    [CmdletBinding()]
+                    param
+                    (
+                    )
+
+                    Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
+                    Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
+                    Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0 -Scope 'It'
+                    Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
+                    Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
+                }
+
+                BeforeEach {
+                    Reset-TestGroup
+
                     Mock -CommandName 'Get-Group' -MockWith { }
                     Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
                     Mock -CommandName 'ConvertTo-UniquePrincipalsList' -MockWith {
@@ -1154,489 +1246,479 @@ Describe 'GroupResource Unit Tests' {
                     Mock -CommandName 'Remove-DisposableObject' -MockWith { }
                     Mock -CommandName 'Get-PrincipalContext' -MockWith { return $script:testPrincipalContext }
                     Mock -CommandName 'Get-Group' -MockWith { }
-
-                    function Assert-GroupMembersNotChangedOnFullSKU
-                    {
-                        [CmdletBinding()]
-                        param
-                        (
-                        )
-
-                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Add-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                        Assert-MockCalled -CommandName 'Remove-Group' -Times 0 -Scope 'It'
-                    }
-
-                    Context 'When Ensure is absent and the group does not exist' {
-                        It 'Should not attempt to remove an absent group' {
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                            Assert-MockCalled -CommandName 'Remove-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName } -Times 0 -Scope 'It'
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
-                        }
-                    }
-
-                    Context 'When Ensure is absent and the group exists' {
-                        It 'Should remove an existing group' {
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                            Assert-MockCalled -CommandName 'Remove-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName } -Scope 'It'
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist' {
-                        It 'Should create an empty group' {
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and Description is passed' {
-                        It 'Should create an empty group with a description' {
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Group.Description -eq $script:testGroupDescription }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and Members is passed with one local member' {
-                        It 'Should create a group with one local member' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $MemberNames -eq $testMembers }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and Members is passed with two local members' {
-                        It 'Should create a group with two local members' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                            Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null  }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with one local member' {
-                        It 'Should create a group with one local member' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $MemberNames -eq $testMembers }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with two local members' {
-                        It 'Should create a group with two local members' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                            Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames)  -eq $null  }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and Members is passed with one member' {
-                        It 'Should add a member to an existing group' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with one member missing from Members list passed' {
-                        It 'Should add a member to an existing group' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                            Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and MembersToInclude is passed with one member' {
-                        It 'Should add a member to an existing group' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with one member missing from Members list passed' {
-                        It 'Should add a member to an existing group' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                            Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with one member not in the Members list passed' {
-                        It 'Should remove a member from an existing group' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with containing members and an empty Members list passed' {
-                        It 'Should clear all members from an existing group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Clear-GroupMembers' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with a member contained in the MembersToExclude list passed' {
-                        It 'Should remove a member from an existing group' {
-                            $testMembers = @( $script:testUserPrincipal2.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with Members passed that require one member to be added and one removed' {
-                        It 'Should add a user and remove a user' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal3.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal3 }
-                            Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with MembersToInclude and MembersToExclude passed that require one member to be added and one removed' {
-                        It 'Should add a user and remove a user' {
-                            $testMembersToInclude = @( $script:testUserPrincipal3.Name )
-                            $testMembersToExclude = @( $script:testUserPrincipal2.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembersToInclude -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembersToExclude -DifferenceObject $MemberNames) -eq $null }
-                            Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal3 }
-                            Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
-                            Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Members and MembersToInclude are both specified' {
-                        It 'Should throw expected exception' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-                            $testMembersToInclude = @( $script:testUserPrincipal3.Name )
-
-                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
-
-                            { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-                    }
-
-                    Context 'When Members and MembersToExclude are both specified' {
-                        It 'Should throw expected exception' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-                            $testMembersToExclude = @( $script:testUserPrincipal3.Name )
-
-                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
-
-                            { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-                    }
-
-                    Context 'When MembersToInclude and MembersToExclude both contain the same member' {
-                        It 'Should throw expected exception' {
-                            $testMembersToInclude = @( $script:testUserPrincipal1.Name )
-                            $testMembersToExclude = @( $script:testUserPrincipal1.Name )
-
-                            $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
-
-                            { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with members already containing all principals in the MembersToInclude' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnFullSKU
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with members not containing any of the principals in the MembersToExclude' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( $script:testUserPrincipal3.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnFullSKU
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with members that match the Members' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnFullSKU
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and the MembersToInclude is specified but Empty' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnFullSKU
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and the MembersToExclude is specified but Empty' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnFullSKU
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and both MembersToInclude and MembersToExclude are empty' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -MembersToExclude $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnFullSKU
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with no members and empty Members passed' {
-                        It 'Should not modify the group' {
-                            $testMembers = @( )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
-
-                            Assert-GroupMembersNotChangedOnFullSKU
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and no changes are made to the group' {
-                        It 'Should not save group' {
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                            Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and Credential is passed when using Members' {
-                        It 'Should pass Credential to all appropriate functions' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and Credential is passed when using MembersToInclude' {
-                        It 'Should pass Credential to all appropriate functions' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Credential $script:testCredential -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and Credential is passed when using MembersToExclude' {
-                        It 'Should pass Credential to all appropriate functions' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
-
-                            Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Credential $script:testCredential -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                        }
+                }
+
+                Context 'When Ensure is absent and the group does not exist' {
+                    It 'Should not attempt to remove an absent group' {
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                        Assert-MockCalled -CommandName 'Remove-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName } -Times 0 -Scope 'It'
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
                     }
                 }
 
-                Describe 'GroupResource\Test-TargetResourceOnFullSKU' {
+                Context 'When Ensure is absent and the group exists' {
+                    It 'Should remove an existing group' {
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                        Assert-MockCalled -CommandName 'Remove-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName } -Scope 'It'
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist' {
+                    It 'Should create an empty group' {
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and Description is passed' {
+                    It 'Should create an empty group with a description' {
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $Group.Description -eq $script:testGroupDescription }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and Members is passed with one local member' {
+                    It 'Should create a group with one local member' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $MemberNames -eq $testMembers }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and Members is passed with two local members' {
+                    It 'Should create a group with two local members' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                        Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null  }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with one local member' {
+                    It 'Should create a group with one local member' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $MemberNames -eq $testMembers }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist and MembersToInclude is passed with two local members' {
+                    It 'Should create a group with two local members' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                        Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' } -MockWith { return $testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.GroupPrincipal' }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames)  -eq $null  }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and Members is passed with one member' {
+                    It 'Should add a member to an existing group' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with one member missing from Members list passed' {
+                    It 'Should add a member to an existing group' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and MembersToInclude is passed with one member' {
+                    It 'Should add a member to an existing group' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal1 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with one member missing from Members list passed' {
+                    It 'Should add a member to an existing group' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                        Assert-MockCalled -CommandName 'Remove-GroupMember' -Times 0
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with one member not in the Members list passed' {
+                    It 'Should remove a member from an existing group' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with containing members and an empty Members list passed' {
+                    It 'Should clear all members from an existing group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Clear-GroupMembers' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with a member contained in the MembersToExclude list passed' {
+                    It 'Should remove a member from an existing group' {
+                        $testMembers = @( $script:testUserPrincipal2.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with Members passed that require one member to be added and one removed' {
+                    It 'Should add a user and remove a user' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal3.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembers -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal3 }
+                        Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with MembersToInclude and MembersToExclude passed that require one member to be added and one removed' {
+                    It 'Should add a user and remove a user' {
+                        $testMembersToInclude = @( $script:testUserPrincipal3.Name )
+                        $testMembersToExclude = @( $script:testUserPrincipal2.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembersToInclude -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { (Compare-Object -ReferenceObject $testMembersToExclude -DifferenceObject $MemberNames) -eq $null }
+                        Assert-MockCalled -CommandName 'Add-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal3 }
+                        Assert-MockCalled -CommandName 'Remove-GroupMember' -ParameterFilter { $Group.Name -eq $script:testGroupName -and $MemberAsPrincipal -eq $script:testUserPrincipal2 }
+                        Assert-MockCalled -CommandName 'Save-Group' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Members and MembersToInclude are both specified' {
+                    It 'Should throw expected exception' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                        $testMembersToInclude = @( $script:testUserPrincipal3.Name )
+
+                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When Members and MembersToExclude are both specified' {
+                    It 'Should throw expected exception' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                        $testMembersToExclude = @( $script:testUserPrincipal3.Name )
+
+                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When MembersToInclude and MembersToExclude both contain the same member' {
+                    It 'Should throw expected exception' {
+                        $testMembersToInclude = @( $script:testUserPrincipal1.Name )
+                        $testMembersToExclude = @( $script:testUserPrincipal1.Name )
+
+                        $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
+
+                        { Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with members already containing all principals in the MembersToInclude' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnFullSKU
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with members not containing any of the principals in the MembersToExclude' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( $script:testUserPrincipal3.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnFullSKU
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with members that match the Members' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnFullSKU
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and the MembersToInclude is specified but Empty' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnFullSKU
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and the MembersToExclude is specified but Empty' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnFullSKU
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and both MembersToInclude and MembersToExclude are empty' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -MembersToExclude $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnFullSKU
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with no members and empty Members passed' {
+                    It 'Should not modify the group' {
+                        $testMembers = @( )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present'
+
+                        Assert-GroupMembersNotChangedOnFullSKU
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and no changes are made to the group' {
+                    It 'Should not save group' {
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                        Assert-MockCalled -CommandName 'Save-Group' -Times 0 -Scope 'It'
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject' -Scope 'It'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and Credential is passed when using Members' {
+                    It 'Should pass Credential to all appropriate functions' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and Credential is passed when using MembersToInclude' {
+                    It 'Should pass Credential to all appropriate functions' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and Credential is passed when using MembersToExclude' {
+                    It 'Should pass Credential to all appropriate functions' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
+
+                        Set-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                    }
+                }
+            }
+
+            Describe 'GroupResource\Test-TargetResourceOnFullSKU' {
+                BeforeEach {
+                    Reset-TestGroup
+
                     Mock -CommandName 'Get-Group' -MockWith { return $script:testGroup }
                     Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
                     Mock -CommandName 'ConvertTo-UniquePrincipalsList' -MockWith {
@@ -1662,330 +1744,334 @@ Describe 'GroupResource Unit Tests' {
 
                     Mock -CommandName 'Remove-DisposableObject' -MockWith { }
                     Mock -CommandName 'Get-PrincipalContext' -MockWith { return $script:testPrincipalContext }
+                }
 
-                    Context 'When Ensure is absent and the group does not exist' {
-                        It 'Should return true and expected mocks are called' {
-                            Mock -CommandName 'Get-Group' -MockWith { }
+                Context 'When Ensure is absent and the group does not exist' {
+                    It 'Should return true and expected mocks are called' {
+                        Mock -CommandName 'Get-Group' -MockWith { }
 
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $true
 
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is absent and the group exists' {
-                        It 'Should return false and expected mocks are called' {
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group does not exist' {
-                        It 'Should return false and expected mocks are called' {
-                            Mock -CommandName 'Get-Group' -MockWith { }
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists' {
-                        It 'Should return true and expected mocks are called' {
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and Description matches' {
-                        It 'Should return true and expected mocks are called' {
-                            $script:testGroup.Description = $script:testGroupDescription
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and Description does not match' {
-                        It 'Should return false and expected mocks are called' {
-                            $script:testGroup.Description = $script:testGroupDescription
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and with no members and Members should be empty' {
-                        It 'Should return true and expected mocks are called' {
-                            $testMembers = @( )
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists mismatching number of members when passing Members' {
-                        It 'Should return false and expected mocks are called' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with missing member when passing MembersToInclude' {
-                        It 'Should return false and expected mocks are called' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists with missing member when passing MembersToExclude' {
-                        It 'Should return true and expected mocks are called' {
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists containing member specified by MembersToExclude' {
-                        It 'Should return false and expected mocks are called' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists containing member specified by MembersToInclude' {
-                        It 'Should return true and expected mocks are called' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and current members matches Members' {
-                        It 'Should return true and expected mocks are called' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Ensure is present and the group exists and current members do not match Members' {
-                        It 'Should return false and expected mocks are called' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal3 )
-
-                            Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext'
-                            Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'Remove-DisposableObject'
-                        }
-                    }
-
-                    Context 'When Credential is passed with Members' {
-                        It 'Should pass Credential to all appropriate functions' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
-                        }
-                    }
-
-                    Context 'When Credential is passed with MembersToInclude' {
-                        It 'Should pass Credential to all appropriate functions' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Credential $script:testCredential -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
-                        }
-                    }
-
-                    Context 'When Credential is passed with MembersToExclude' {
-                        It 'Should pass Credential to all appropriate functions' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1.Name )
-
-                            $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Credential $script:testCredential -Ensure 'Present'
-
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
-                            Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
-                        }
-                    }
-
-                    Context 'When Members and MembersToInclude are both specified' {
-                        It 'Should throw expected exception' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-                            $testMembersToInclude = @( $script:testUserPrincipal3.Name )
-
-                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
-
-                            { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-                    }
-
-                    Context 'When Members and MembersToExclude are both specified' {
-                        It 'Should throw expected exception' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-                            $testMembersToExclude = @( $script:testUserPrincipal3.Name )
-
-                            $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
-
-                            { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
-                    }
-
-                    Context 'When MembersToInclude and MembersToExclude both contain the same member' {
-                        It 'Should throw expected exception' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            $testMembersToInclude = @( $script:testUserPrincipal1.Name )
-                            $testMembersToExclude = @( $script:testUserPrincipal1.Name )
-
-                            $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
-
-                            { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
-                        }
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
                     }
                 }
 
-                Describe 'GroupResource\Get-MembersOnFullSKU' {
+                Context 'When Ensure is absent and the group exists' {
+                    It 'Should return false and expected mocks are called' {
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Absent' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -Scope 'It'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName } -Scope 'It'
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group does not exist' {
+                    It 'Should return false and expected mocks are called' {
+                        Mock -CommandName 'Get-Group' -MockWith { }
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists' {
+                    It 'Should return true and expected mocks are called' {
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and Description matches' {
+                    It 'Should return true and expected mocks are called' {
+                        $script:testGroup.Description = $script:testGroupDescription
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description $script:testGroupDescription -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and Description does not match' {
+                    It 'Should return false and expected mocks are called' {
+                        $script:testGroup.Description = $script:testGroupDescription
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Description 'Wrong description' -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and with no members and Members should be empty' {
+                    It 'Should return true and expected mocks are called' {
+                        $testMembers = @( )
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists mismatching number of members when passing Members' {
+                    It 'Should return false and expected mocks are called' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with missing member when passing MembersToInclude' {
+                    It 'Should return false and expected mocks are called' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists with missing member when passing MembersToExclude' {
+                    It 'Should return true and expected mocks are called' {
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists containing member specified by MembersToExclude' {
+                    It 'Should return false and expected mocks are called' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists containing member specified by MembersToInclude' {
+                    It 'Should return true and expected mocks are called' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and current members matches Members' {
+                    It 'Should return true and expected mocks are called' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $true
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Ensure is present and the group exists and current members do not match Members' {
+                    It 'Should return false and expected mocks are called' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1, $script:testUserPrincipal3 )
+
+                        Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Ensure 'Present' | Should -Be $false
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext'
+                        Assert-MockCalled -CommandName 'Get-Group' -ParameterFilter { $GroupName -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'Remove-DisposableObject'
+                    }
+                }
+
+                Context 'When Credential is passed with Members' {
+                    It 'Should pass Credential to all appropriate functions' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                    }
+                }
+
+                Context 'When Credential is passed with MembersToInclude' {
+                    It 'Should pass Credential to all appropriate functions' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                    }
+                }
+
+                Context 'When Credential is passed with MembersToExclude' {
+                    It 'Should pass Credential to all appropriate functions' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1.Name )
+
+                        $null = Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToExclude $testMembers -Credential $script:testCredential -Ensure 'Present'
+
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'ConvertTo-UniquePrincipalsList' -ParameterFilter { $Credential -eq $script:testCredential  }
+                    }
+                }
+
+                Context 'When Members and MembersToInclude are both specified' {
+                    It 'Should throw expected exception' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                        $testMembersToInclude = @( $script:testUserPrincipal3.Name )
+
+                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToInclude'
+
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToInclude $testMembersToInclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When Members and MembersToExclude are both specified' {
+                    It 'Should throw expected exception' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembers = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                        $testMembersToExclude = @( $script:testUserPrincipal3.Name )
+
+                        $errorMessage = $script:localizedData.MembersAndIncludeExcludeConflict -f 'Members', 'MembersToExclude'
+
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -Members $testMembers -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+
+                Context 'When MembersToInclude and MembersToExclude both contain the same member' {
+                    It 'Should throw expected exception' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        $testMembersToInclude = @( $script:testUserPrincipal1.Name )
+                        $testMembersToExclude = @( $script:testUserPrincipal1.Name )
+
+                        $errorMessage = $script:localizedData.IncludeAndExcludeConflict -f $script:testUserPrincipal1.Name, 'MembersToInclude', 'MembersToExclude'
+
+                        { Test-TargetResourceOnFullSKU -GroupName $script:testGroupName -MembersToInclude $testMembersToInclude -MembersToExclude $testMembersToExclude -Ensure 'Present' } | Should -Throw $errorMessage
+                    }
+                }
+            }
+
+            Describe 'GroupResource\Get-MembersOnFullSKU' {
+                BeforeEach {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                }
 
-                    Context 'When called with a group that does not have any members' {
-                        It 'Should return nothing' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
+                Context 'When called with a group that does not have any members' {
+                    It 'Should return nothing' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { }
 
-                            Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
+                        Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
 
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-                    }
-
-                    Context 'When called with a group that has only local memebers' {
-                        It 'Should return principal names' {
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
-
-                            Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
-
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-                    }
-
-                    Context 'When called with group that has domain members' {
-                        It 'Should return exepcted principal names with domains' {
-                            $testDomainUser1 = @{
-                                Name = 'TestDomainUser1'
-                                SamAccountName = 'TestSamAccountName1'
-                                ContextType = [System.DirectoryServices.AccountManagement.ContextType]::Domain
-                                Context = @{
-                                    Name = 'TestDomain1'
-                                }
-                                StructuralObjectClass = 'Domain'
-                            }
-
-                            $domainName2 = 'TestDomain2'
-
-                            $testDomainUser2 = @{
-                                Name = 'TestDomainUser2'
-                                SamAccountName = 'TestSamAccountName2'
-                                ContextType = [System.DirectoryServices.AccountManagement.ContextType]::Domain
-                                Context = @{
-                                    Name = "$domainName2.WithDot"
-                                }
-                                StructuralObjectClass = 'Computer'
-                            }
-
-                            $expectedName1 = "$($testDomainUser1.Context.Name)\$($testDomainUser1.SamAccountName)"
-                            $expectedName2 = "$($domainName2)\$($testDomainUser2.Name)"
-                            $expectedGetMembersResult = @( $expectedName1, $expectedName2 )
-
-                            Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $testDomainUser1, $testDomainUser2 ) }
-
-                            $getMembersResult = Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
-
-                            (Compare-Object -ReferenceObject $expectedGetMembersResult -DifferenceObject $getMembersResult) | Should -Be $null
-
-                            Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                     }
                 }
 
-                Describe 'GroupResource\Get-MembersAsPrincipalsList' {
+                Context 'When called with a group that has only local memebers' {
+                    It 'Should return principal names' {
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $script:testUserPrincipal1, $script:testUserPrincipal2 ) }
+
+                        Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be @( $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+
+                Context 'When called with group that has domain members' {
+                    It 'Should return exepcted principal names with domains' {
+                        $testDomainUser1 = @{
+                            Name = 'TestDomainUser1'
+                            SamAccountName = 'TestSamAccountName1'
+                            ContextType = [System.DirectoryServices.AccountManagement.ContextType]::Domain
+                            Context = @{
+                                Name = 'TestDomain1'
+                            }
+                            StructuralObjectClass = 'Domain'
+                        }
+
+                        $domainName2 = 'TestDomain2'
+
+                        $testDomainUser2 = @{
+                            Name = 'TestDomainUser2'
+                            SamAccountName = 'TestSamAccountName2'
+                            ContextType = [System.DirectoryServices.AccountManagement.ContextType]::Domain
+                            Context = @{
+                                Name = "$domainName2.WithDot"
+                            }
+                            StructuralObjectClass = 'Computer'
+                        }
+
+                        $expectedName1 = "$($testDomainUser1.Context.Name)\$($testDomainUser1.SamAccountName)"
+                        $expectedName2 = "$($domainName2)\$($testDomainUser2.Name)"
+                        $expectedGetMembersResult = @( $expectedName1, $expectedName2 )
+
+                        Mock -CommandName 'Get-MembersAsPrincipalsList' -MockWith { return @( $testDomainUser1, $testDomainUser2 ) }
+
+                        $getMembersResult = Get-MembersOnFullSKU -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
+
+                        (Compare-Object -ReferenceObject $expectedGetMembersResult -DifferenceObject $getMembersResult) | Should -Be $null
+
+                        Assert-MockCalled -CommandName 'Get-MembersAsPrincipalsList' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                    }
+                }
+            }
+
+            Describe 'GroupResource\Get-MembersAsPrincipalsList' {
+                BeforeEach {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
                     $memberDirectoryEntry1 = @{
@@ -2024,93 +2110,95 @@ Describe 'GroupResource Unit Tests' {
                     }
 
                     Mock -CommandName 'Resolve-SidToPrincipal' -MockWith { return 'FakeSidValue' }
+                }
 
-                    Context 'When called with Group that contains no group members' {
-                        It 'Should return null and call expected mocks' {
-                            Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
-                            Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                        }
-                    }
-
-                    Context 'When called with Group that contains only stale group members' {
-                        It 'Should return null and call expected mocks' {
-                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry3 ) }
-
-                            $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables -WarningAction 'SilentlyContinue'
-                            $getMembersResult | Should -Be $null
-
-                            Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' }
-                        }
-                    }
-
-                    Context 'When called with Group that contains two non-stale local members' {
-                        It 'Should return a list of two members and call expected mocks' {
-                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
-
-                            $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
-                            $getMembersResult.Count | Should -Be 2
-
-                            Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'domainname' }
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'machinename' }
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'domainname' }
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'machinename' }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue1' }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue2' }
-                            Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'domainname' }
-                            Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'machinename' }
-                        }
-                    }
-
-                    Context 'When called with Group that contains two non-stale domain members' {
-                        It 'Should return a list of two members and call expected mocks' {
-                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
-                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
-
-                            $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
-                            $getMembersResult.Count | Should -Be 2
-
-                            Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'domainname' }
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'machinename' }
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'domainname' }
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'machinename' }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue1' }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue2' }
-                            Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'domainname' }
-                            Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'machinename' }
-                        }
-                    }
-
-                    Context 'When called with Credential' {
-                        It 'Should pass Credential to appropriate functions' {
-                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
-                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
-
-                            $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential }
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential}
-                        }
-                    }
-
-                    Context 'When called with a group that contains a principal that can not be found in the domain' {
-                        It 'Should throw expected exception' {
-                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
-                            Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
-                            Mock -CommandName 'Get-PrincipalContext' -MockWith { }
-
-                            $errorMessage = ($script:localizedData.DomainCredentialsRequired -f 'accountname')
-
-                            { Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables } | Should -Throw $errorMessage
-                        }
+                Context 'When called with Group that contains no group members' {
+                    It 'Should return null and call expected mocks' {
+                        Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables | Should -Be $null
+                        Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
                     }
                 }
 
-                Describe 'GroupResource\ConvertTo-UniquePrincipalsList' {
+                Context 'When called with Group that contains only stale group members' {
+                    It 'Should return null and call expected mocks' {
+                        Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry3 ) }
+
+                        $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables -WarningAction 'SilentlyContinue'
+                        $getMembersResult | Should -Be $null
+
+                        Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' }
+                    }
+                }
+
+                Context 'When called with Group that contains two non-stale local members' {
+                    It 'Should return a list of two members and call expected mocks' {
+                        Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
+
+                        $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        $getMembersResult.Count | Should -Be 2
+
+                        Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'domainname' }
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'machinename' }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'domainname' }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'machinename' }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue1' }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue2' }
+                        Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'domainname' }
+                        Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'machinename' }
+                    }
+                }
+
+                Context 'When called with Group that contains two non-stale domain members' {
+                    It 'Should return a list of two members and call expected mocks' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                        Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
+
+                        $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        $getMembersResult.Count | Should -Be 2
+
+                        Assert-MockCalled -CommandName 'Get-GroupMembersFromDirectoryEntry' -ParameterFilter { $Group.Name -eq $script:testGroupName }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.DirectoryEntry' } -Times 2 -Scope 'It'
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'domainname' }
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq 'machinename' }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'domainname' }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq 'machinename' }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue1' }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.Security.Principal.SecurityIdentifier' -and $ArgumentList[0] -eq 'SidValue2' }
+                        Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'domainname' }
+                        Assert-MockCalled -CommandName 'Resolve-SidToPrincipal' -ParameterFilter { $Sid -eq 'S-1-0-0' -and $Scope -eq 'machinename' }
+                    }
+                }
+
+                Context 'When called with Credential' {
+                    It 'Should pass Credential to appropriate functions' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                        Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
+
+                        $getMembersResult = Get-MembersAsPrincipalsList -Group $script:testGroup -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential }
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential}
+                    }
+                }
+
+                Context 'When called with a group that contains a principal that can not be found in the domain' {
+                    It 'Should throw expected exception' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                        Mock -CommandName 'Get-GroupMembersFromDirectoryEntry' -MockWith { return @( $memberDirectoryEntry1, $memberDirectoryEntry2 ) }
+                        Mock -CommandName 'Get-PrincipalContext' -MockWith { }
+
+                        $errorMessage = ($script:localizedData.DomainCredentialsRequired -f 'accountname')
+
+                        { Get-MembersAsPrincipalsList -Group $script:testGroup -PrincipalContextCache $principalContextCache -Disposables $disposables } | Should -Throw $errorMessage
+                    }
+                }
+            }
+
+            Describe 'GroupResource\ConvertTo-UniquePrincipalsList' {
+                BeforeEach {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
@@ -2134,45 +2222,47 @@ Describe 'GroupResource Unit Tests' {
                             $testDomainUser1.Name { return $testDomainUser1 }
                         }
                     }
+                }
 
-                    Context 'When called with a list of local principals that contains duplicates' {
-                        It 'Should not return duplicate local prinicpals' {
-                            $memberNames = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
+                Context 'When called with a list of local principals that contains duplicates' {
+                    It 'Should not return duplicate local prinicpals' {
+                        $memberNames = @( $script:testUserPrincipal1.Name, $script:testUserPrincipal1.Name, $script:testUserPrincipal2.Name )
 
-                            $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
-                            $uniquePrincipalsList | Should -Be @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
+                        $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        $uniquePrincipalsList | Should -Be @( $script:testUserPrincipal1, $script:testUserPrincipal2 )
 
-                            foreach ($passedInMemberName in $memberNames)
-                            {
-                                Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $MemberName -eq $passedInMemberName }
-                            }
-                        }
-                    }
-
-                    Context 'When called with a list of domain principals that contains duplicates' {
-                        It 'Should not return duplicate domain prinicpals' {
-                            $memberNames = @( $testDomainUser1.Name, $testDomainUser1.Name )
-
-                            $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
-                            $uniquePrincipalsList | Should -Be @( $testDomainUser1 )
-
-                            foreach ($passedInMemberName in $memberNames)
-                            {
-                                Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $MemberName -eq $passedInMemberName }
-                            }
-                        }
-                    }
-
-                    Context 'When called with a list of domain principals that does not contain duplicates and a credential is passed' {
-                        It 'Should pass Credential to appropriate functions' {
-                            ConvertTo-UniquePrincipalsList -MemberNames @( $script:testUserPrincipal1 ) -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
-
-                            Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $Credential -eq $script:testCredential }
+                        foreach ($passedInMemberName in $memberNames)
+                        {
+                            Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $MemberName -eq $passedInMemberName }
                         }
                     }
                 }
 
-                Describe 'GroupResource\ConvertTo-Principal' {
+                Context 'When called with a list of domain principals that contains duplicates' {
+                    It 'Should not return duplicate domain prinicpals' {
+                        $memberNames = @( $testDomainUser1.Name, $testDomainUser1.Name )
+
+                        $uniquePrincipalsList = ConvertTo-UniquePrincipalsList -MemberNames $memberNames -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        $uniquePrincipalsList | Should -Be @( $testDomainUser1 )
+
+                        foreach ($passedInMemberName in $memberNames)
+                        {
+                            Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $MemberName -eq $passedInMemberName }
+                        }
+                    }
+                }
+
+                Context 'When called with a list of domain principals that does not contain duplicates and a credential is passed' {
+                    It 'Should pass Credential to appropriate functions' {
+                        ConvertTo-UniquePrincipalsList -MemberNames @( $script:testUserPrincipal1 ) -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+
+                        Assert-MockCalled -CommandName 'ConvertTo-Principal' -ParameterFilter { $Credential -eq $script:testCredential }
+                    }
+                }
+            }
+
+            Describe 'GroupResource\ConvertTo-Principal' {
+                BeforeEach {
                     $principalContextCache = @{}
                     $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
@@ -2187,64 +2277,66 @@ Describe 'GroupResource Unit Tests' {
                             $script:testUserPrincipal3.Name { return $script:testUserPrincipal3 }
                         }
                     }
+                }
 
-                    Context 'When called with a local machine member that is not in the principal context cache' {
-                        It 'Should return principal with local member name' {
-                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
+                Context 'When called with a local machine member that is not in the principal context cache' {
+                    It 'Should return principal with local member name' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                            $convertToPrincipalResult = ConvertTo-Principal `
-                                -MemberName $script:testUserPrincipal1.Name `
-                                -PrincipalContextCache $principalContextCache `
-                                -Disposables $disposables
+                        $convertToPrincipalResult = ConvertTo-Principal `
+                            -MemberName $script:testUserPrincipal1.Name `
+                            -PrincipalContextCache $principalContextCache `
+                            -Disposables $disposables
 
-                            $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
+                        $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
 
-                            Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq $script:localDomain }
-                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $IdentityValue -eq $script:testUserPrincipal1.Name }
-                        }
-                    }
-
-                    Context 'When called with a domain member that is not in the principal context cache' {
-                        It 'Should attempt to resolve domain member with domain trust' {
-                            $convertToPrincipalResult = ConvertTo-Principal `
-                                -MemberName $script:testUserPrincipal1.Name `
-                                -PrincipalContextCache $principalContextCache `
-                                -Disposables $disposables
-
-                            $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
-
-                            Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq $script:localDomain }
-                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $IdentityValue -eq $script:testUserPrincipal1.Name }
-                        }
-                    }
-
-                    Context 'When called with a domain member that is not in the principal context cache and a credential is passed' {
-                        It 'Should pass Credential to appropriate functions' {
-                            $null = ConvertTo-Principal -MemberName $script:testUserPrincipal1.Name -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
-
-                            Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential }
-                        }
-                    }
-
-                    Context 'When called with a domain member that is not in the principal context cache and could not be found' {
-                        It 'Should throw if principal cannot be found' {
-                            Mock -CommandName 'Find-Principal' -MockWith { }
-
-                            $errorMessage = ($script:localizedData.CouldNotFindPrincipal -f $script:testUserPrincipal1.Name)
-
-                            { $convertToPrincipalResult = ConvertTo-Principal `
-                                -MemberName $script:testUserPrincipal1.Name `
-                                -PrincipalContextCache $principalContextCache `
-                                -Disposables $disposables } | Should -Throw $errorMessage
-                        }
+                        Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq $script:localDomain }
+                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $IdentityValue -eq $script:testUserPrincipal1.Name }
                     }
                 }
 
-                Describe 'GroupResource\Resolve-SidToPrincipal' {
+                Context 'When called with a domain member that is not in the principal context cache' {
+                    It 'Should attempt to resolve domain member with domain trust' {
+                        $convertToPrincipalResult = ConvertTo-Principal `
+                            -MemberName $script:testUserPrincipal1.Name `
+                            -PrincipalContextCache $principalContextCache `
+                            -Disposables $disposables
+
+                        $convertToPrincipalResult | Should -Be $script:testUserPrincipal1
+
+                        Assert-MockCalled -CommandName 'Split-MemberName' -ParameterFilter { $MemberName -eq $script:testUserPrincipal1.Name }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Scope -eq $script:localDomain }
+                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $IdentityValue -eq $script:testUserPrincipal1.Name }
+                    }
+                }
+
+                Context 'When called with a domain member that is not in the principal context cache and a credential is passed' {
+                    It 'Should pass Credential to appropriate functions' {
+                        $null = ConvertTo-Principal -MemberName $script:testUserPrincipal1.Name -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+
+                        Assert-MockCalled -CommandName 'Get-PrincipalContext' -ParameterFilter { $Credential -eq $script:testCredential }
+                    }
+                }
+
+                Context 'When called with a domain member that is not in the principal context cache and could not be found' {
+                    It 'Should throw if principal cannot be found' {
+                        Mock -CommandName 'Find-Principal' -MockWith { }
+
+                        $errorMessage = ($script:localizedData.CouldNotFindPrincipal -f $script:testUserPrincipal1.Name)
+
+                        { $convertToPrincipalResult = ConvertTo-Principal `
+                            -MemberName $script:testUserPrincipal1.Name `
+                            -PrincipalContextCache $principalContextCache `
+                            -Disposables $disposables } | Should -Throw $errorMessage
+                    }
+                }
+            }
+
+            Describe 'GroupResource\Resolve-SidToPrincipal' {
+                BeforeEach {
                     $testSidValue = 'S-1-0-0'
                     $testSid = New-Object -TypeName 'System.Security.Principal.SecurityIdentifier' -ArgumentList @( $testSidValue )
                     $fakePrincipal = 'FakePrincipal'
@@ -2252,169 +2344,170 @@ Describe 'GroupResource Unit Tests' {
 
                     Mock -CommandName 'Find-Principal' -MockWith { }
                     Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                }
 
-                    Context 'When called with a local principal that does not esxist' {
-                        It 'Should throw when principal not found' {
-                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
+                Context 'When called with a local principal that does not esxist' {
+                    It 'Should throw when principal not found' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                            { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
+                        { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
 
-                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
-                        }
-                    }
-
-                    Context 'When called with a domain principal that does not exist' {
-                        It 'Should throw when principal not found' {
-                            $customDomain = 'CustomDomain'
-
-                            { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $customDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
-
-                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
-                        }
-                    }
-
-                    Context 'When called with a local principal that exists' {
-                        It 'Should return found principal' {
-                            Mock -CommandName 'Find-Principal' -MockWith { return $fakePrincipal }
-
-                            Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain | Should -Be $fakePrincipal
-                            Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
-                        }
+                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
                     }
                 }
 
-                Describe 'GroupResource\Get-PrincipalContext' {
+                Context 'When called with a domain principal that does not exist' {
+                    It 'Should throw when principal not found' {
+                        $customDomain = 'CustomDomain'
+
+                        { Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $customDomain } | Should -Throw ($script:localizedData.CouldNotFindPrincipal -f $testSidValue)
+
+                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                    }
+                }
+
+                Context 'When called with a local principal that exists' {
+                    It 'Should return found principal' {
+                        Mock -CommandName 'Find-Principal' -MockWith { return $fakePrincipal }
+
+                        Resolve-SidToPrincipal -Sid $testSid -PrincipalContext $script:testPrincipalContext -Scope $script:localDomain | Should -Be $fakePrincipal
+                        Assert-MockCalled -CommandName 'Find-Principal' -ParameterFilter { $PrincipalContext -eq $script:testPrincipalContext -and $IdentityType -eq $sidIdentityType -and $IdentityValue -eq $testSidValue }
+                    }
+                }
+            }
+
+            Describe 'GroupResource\Get-PrincipalContext' {
+                BeforeEach {
                     $fakePrincipalContext = 'FakePrincipalContext'
-
-                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
-                    Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -MockWith { $fakePrincipalContext }
-
                     $localMachineContext = [System.DirectoryServices.AccountManagement.ContextType]::Machine
                     $customDomainContext = [System.DirectoryServices.AccountManagement.ContextType]::Domain
 
-                    Context 'When called with a local principal that does not exist in the principal context cache' {
-                        It 'Should create a new local principal context' {
-                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
+                    Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $false }
+                    Mock -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -MockWith { $fakePrincipalContext }
+                }
 
-                            $principalContextCache = @{}
-                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                Context 'When called with a local principal that does not exist in the principal context cache' {
+                    It 'Should create a new local principal context' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                            $localScope = 'localhost'
+                        $principalContextCache = @{}
+                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                            Get-PrincipalContext -Scope $localScope -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        $localScope = 'localhost'
 
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $localScope }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and $ArgumentList.Contains($localMachineContext) }
+                        Get-PrincipalContext -Scope $localScope -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                            $principalContextCache.ContainsKey($localScope) | Should -Be $false
-                            $principalContextCache.$script:localDomain | Should -Be $fakePrincipalContext
-                            $disposables.Contains($fakePrincipalContext) | Should -Be $true
-                        }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $localScope }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and $ArgumentList.Contains($localMachineContext) }
+
+                        $principalContextCache.ContainsKey($localScope) | Should -Be $false
+                        $principalContextCache.$script:localDomain | Should -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
                     }
+                }
 
-                    Context 'When called with a domain principal that does exist in the principal context cache' {
-                        It 'Should return the local principal context from the cache' {
-                            Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
+                Context 'When called with a domain principal that does exist in the principal context cache' {
+                    It 'Should return the local principal context from the cache' {
+                        Mock -CommandName 'Test-IsLocalMachine' -MockWith { return $true }
 
-                            $principalContextCache = @{ $script:localDomain = $script:testPrincipalContext }
-                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                        $principalContextCache = @{ $script:localDomain = $script:testPrincipalContext }
+                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                            Get-PrincipalContext -Scope $script:localDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        Get-PrincipalContext -Scope $script:localDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $script:localDomain }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
 
-                            $principalContextCache.$script:localDomain | Should -Not -Be $fakePrincipalContext
-                            $disposables.Contains($fakePrincipalContext) | Should -Be $false
-                        }
+                        $principalContextCache.$script:localDomain | Should -Not -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $false
                     }
+                }
 
-                    Context 'When called with a domain principal that does not exist in the principal cache and without a Credential' {
-                        It 'Should create a new domain principal context without a Credential' {
-                            $principalContextCache = @{}
-                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                Context 'When called with a domain principal that does not exist in the principal cache and without a Credential' {
+                    It 'Should create a new domain principal context without a Credential' {
+                        $principalContextCache = @{}
+                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                            $customDomain = 'CustomDomain'
+                        $customDomain = 'CustomDomain'
 
-                            Get-PrincipalContext -Scope $customDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        Get-PrincipalContext -Scope $customDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
 
-                            $principalContextArgumentList = @($customDomainContext, $customDomain)
+                        $principalContextArgumentList = @($customDomainContext, $customDomain)
 
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
-                                (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
+                            (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                            $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
-                            $disposables.Contains($fakePrincipalContext) | Should -Be $true
-                        }
+                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
                     }
+                }
 
-                    Context 'When called with a domain principal that does not exist in the principal cache and with a Credential without a domain' {
-                        It 'Should create a new domain principal context with a credential without a domain' {
-                            $principalContextCache = @{}
-                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                Context 'When called with a domain principal that does not exist in the principal cache and with a Credential without a domain' {
+                    It 'Should create a new domain principal context with a credential without a domain' {
+                        $principalContextCache = @{}
+                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                            $customDomain = 'CustomDomain'
+                        $customDomain = 'CustomDomain'
 
-                            Get-PrincipalContext -Scope $customDomain -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        Get-PrincipalContext -Scope $customDomain -Credential $script:testCredential -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
 
-                            $principalContextArgumentList = @( $customDomainContext, $customDomain, $script:testCredential.GetNetworkCredential().UserName, $script:testCredential.GetNetworkCredential().Password )
+                        $principalContextArgumentList = @( $customDomainContext, $customDomain, $script:testCredential.GetNetworkCredential().UserName, $script:testCredential.GetNetworkCredential().Password )
 
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
-                                (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
+                            (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                            $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
-                            $disposables.Contains($fakePrincipalContext) | Should -Be $true
-                        }
+                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
                     }
+                }
 
-                    Context 'When called with a domain principal that does not exist in the principal cache and with a Credential with a domain' {
-                        It 'Should create a new custom principal context with a credential with a domain' {
-                            $principalContextCache = @{}
-                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                Context 'When called with a domain principal that does not exist in the principal cache and with a Credential with a domain' {
+                    It 'Should create a new custom principal context with a credential with a domain' {
+                        $principalContextCache = @{}
+                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                            $customDomain = 'CustomDomain'
+                        $customDomain = 'CustomDomain'
 
-                            $userNameWithDomain = 'CustomDomain\username'
-                            $testPassword = 'TestPassword'
-                            $secureTestPassword = ConvertTo-SecureString -String $testPassword -AsPlainText -Force
+                        $userNameWithDomain = 'CustomDomain\username'
+                        $testPassword = 'TestPassword'
+                        $secureTestPassword = ConvertTo-SecureString -String $testPassword -AsPlainText -Force
 
-                            $credentialWithDomain = New-Object -TypeName 'System.Management.Automation.PSCredential' -ArgumentList @( $userNameWithDomain, $secureTestPassword )
+                        $credentialWithDomain = New-Object -TypeName 'System.Management.Automation.PSCredential' -ArgumentList @( $userNameWithDomain, $secureTestPassword )
 
-                            Get-PrincipalContext -Scope $customDomain -Credential $credentialWithDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        Get-PrincipalContext -Scope $customDomain -Credential $credentialWithDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
 
-                            $principalContextArgumentList = @( $customDomainContext, $customDomain, $userNameWithDomain, $credentialWithDomain.GetNetworkCredential().Password  )
+                        $principalContextArgumentList = @( $customDomainContext, $customDomain, $userNameWithDomain, $credentialWithDomain.GetNetworkCredential().Password  )
 
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
-                                (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' -and
+                            (Compare-Object -ReferenceObject $principalContextArgumentList -DifferenceObject $ArgumentList) -eq $null }
 
-                            $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
-                            $disposables.Contains($fakePrincipalContext) | Should -Be $true
-                        }
+                        $principalContextCache.$customDomain | Should -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $true
                     }
+                }
 
-                    Context 'When called with a domain principal that exists in the principal context cache' {
-                        It 'Should return a domain principal context from the cache' {
-                            $customDomain = 'CustomDomain'
+                Context 'When called with a domain principal that exists in the principal context cache' {
+                    It 'Should return a domain principal context from the cache' {
+                        $customDomain = 'CustomDomain'
 
-                            $principalContextCache = @{ $customDomain = $script:testPrincipalContext }
-                            $disposables = New-Object -TypeName 'System.Collections.ArrayList'
+                        $principalContextCache = @{ $customDomain = $script:testPrincipalContext }
+                        $disposables = New-Object -TypeName 'System.Collections.ArrayList'
 
-                            Get-PrincipalContext -Scope $customDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
+                        Get-PrincipalContext -Scope $customDomain -PrincipalContextCache $principalContextCache -Disposables $disposables
 
-                            Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
-                            Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
+                        Assert-MockCalled -CommandName 'Test-IsLocalMachine' -ParameterFilter { $Scope -eq $customDomain }
+                        Assert-MockCalled -CommandName 'New-Object' -ParameterFilter { $TypeName -eq 'System.DirectoryServices.AccountManagement.PrincipalContext' } -Times 0 -Scope 'It'
 
-                            $principalContextCache.$customDomain | Should -Not -Be $fakePrincipalContext
-                            $disposables.Contains($fakePrincipalContext) | Should -Be $false
-                        }
+                        $principalContextCache.$customDomain | Should -Not -Be $fakePrincipalContext
+                        $disposables.Contains($fakePrincipalContext) | Should -Be $false
                     }
                 }
             }


### PR DESCRIPTION
#### Pull Request (PR) description

This PR refactors Group and GroupSet tests to meet Pester 4 standards. Also made some tweaks to the tests to use Pester It block `-TestCases` for some tests.

I also tweaked the README.MD style to remove : after resource titles as this is the standard (I had been doing it wrong myself :grin:).

#### This Pull Request (PR) fixes the following issues

- Contributes to #129

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/135)
<!-- Reviewable:end -->
