### PR TITLE
add examples for composite resources

### DIFF
--- a/DscResources/ProcessSet/ProcessSet.schema.psm1
+++ b/DscResources/ProcessSet/ProcessSet.schema.psm1
@@ -51,7 +51,7 @@ Configuration ProcessSet
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true, HelpMessage="The file paths to the executables of the processes to start or stop. Only the names of the files may be specified if they are all accessible through the environment path. Relative paths are not supported.")]
+        [Parameter(Mandatory = $true, HelpMessage = "[Example: ('Group1','Group2')] The file paths to the executables of the processes to start or stop. Only the names of the files may be specified if they are all accessible through the environment path. Relative paths are not supported.")]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $Path,
@@ -87,7 +87,7 @@ Configuration ProcessSet
         [String]
         $WorkingDirectory
     )
-    
+
     $newResourceSetConfigurationParams = @{
         ResourceName = 'WindowsProcess'
         ModuleName = 'PSDscResources'
@@ -97,7 +97,7 @@ Configuration ProcessSet
 
     # Arguments is a key parameter in WindowsProcess resource. Adding it as a common parameter with an empty value string
     $newResourceSetConfigurationParams['Parameters']['Arguments'] = ''
-    
+
     $configurationScriptBlock = New-ResourceSetConfigurationScriptBlock @newResourceSetConfigurationParams
 
     # This script block must be run directly in this configuration in order to resolve variables

--- a/DscResources/ServiceSet/ServiceSet.schema.psm1
+++ b/DscResources/ServiceSet/ServiceSet.schema.psm1
@@ -18,7 +18,7 @@ Import-Module -Name $script:resourceSetHelperFilePath
 
     .PARAMETER Ensure
         Specifies whether or not the set of services should exist.
-        
+
         Set this property to Present to modify a set of services.
         Set this property to Absent to remove a set of services.
 
@@ -51,7 +51,7 @@ Configuration ServiceSet
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true, HelpMessage="An array of the names of the services to configure.")]
+        [Parameter(Mandatory = $true, HelpMessage = "[Example: ('TestService','TestService2')] An array of the names of the services to configure.")]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $Name,
@@ -89,7 +89,7 @@ Configuration ServiceSet
         KeyParameterName = 'Name'
         Parameters = $PSBoundParameters
     }
-    
+
     $configurationScriptBlock = New-ResourceSetConfigurationScriptBlock @newResourceSetConfigurationParams
 
     # This script block must be run directly in this configuration in order to resolve variables

--- a/DscResources/WindowsFeatureSet/WindowsFeatureSet.schema.psm1
+++ b/DscResources/WindowsFeatureSet/WindowsFeatureSet.schema.psm1
@@ -41,7 +41,7 @@ Configuration WindowsFeatureSet
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true, HelpMessage="The name of the roles or features to install or uninstall.")]
+        [Parameter(Mandatory = $true, HelpMessage = "[Example: ('Web-Server','RSAT-File-Services')] The name of the roles or features to install or uninstall.")]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $Name,
@@ -73,7 +73,7 @@ Configuration WindowsFeatureSet
         [System.Management.Automation.Credential()]
         $Credential,
 
-        [Parameter(HelpMessage="The custom file path to which to log this operation. 
+        [Parameter(HelpMessage="The custom file path to which to log this operation.
         If not passed in, the default log path will be used (%windir%\logs\ServerManager.log).")]
         [ValidateNotNullOrEmpty()]
         [String]
@@ -86,7 +86,7 @@ Configuration WindowsFeatureSet
         KeyParameterName = 'Name'
         Parameters = $PSBoundParameters
     }
-    
+
     $configurationScriptBlock = New-ResourceSetConfigurationScriptBlock @newResourceSetConfigurationParams
 
     # This script block must be run directly in this configuration in order to resolve variables

--- a/DscResources/WindowsOptionalFeatureSet/WindowsOptionalFeatureSet.schema.psm1
+++ b/DscResources/WindowsOptionalFeatureSet/WindowsOptionalFeatureSet.schema.psm1
@@ -41,7 +41,7 @@ Configuration WindowsOptionalFeatureSet
     [CmdletBinding()]
     param
     (
-        [Parameter(Mandatory = $true, HelpMessage="The names of the Windows optional features to enable or disable.")]
+        [Parameter(Mandatory = $true, HelpMessage = "[Example: ('TelnetClient','NetFx3')] The names of the Windows optional features to enable or disable.")]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $Name,
@@ -79,7 +79,7 @@ Configuration WindowsOptionalFeatureSet
         KeyParameterName = 'Name'
         Parameters = $PSBoundParameters
     }
-    
+
     $configurationScriptBlock = New-ResourceSetConfigurationScriptBlock @newResourceSetConfigurationParams
 
     # This script block must be run directly in this configuration in order to resolve variables

--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@ The following parameters will be the same for each process in the set:
 ### Unreleased
 
 * Fix Custom DSC Resource Kit PSSA Rule Failures
+* Add text to composite resources to display in Azure Automation authoring
 
 ### 2.10.0.0
 


### PR DESCRIPTION
# Pull Request (PR) description

Add example blocks to composite resource parameters that use arrays as values.

## This Pull Request (PR) fixes the following issues

Currently it is difficult for a new user to understand how to enter an array in to the form in the Azure Portal for these values.  By giving examples, we can render text to demonstrate for users how to provide multiple values.

cc @avkaur @kwirkykat @nitinbps

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/140)
<!-- Reviewable:end -->
