### PR TITLE
Fix msi package tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,6 +577,9 @@ The following parameters will be the same for each process in the set:
 
 ### Unreleased
 
+* Fixes issue where MsiPackage Integration tests fail to make an HTTPS
+  connection if Strong Crypto for .NET is not enabled.
+  [Issue #142](https://github.com/PowerShell/PSDscResources/issues/142)
 * Fix Custom DSC Resource Kit PSSA Rule Failures
 
 ### 2.10.0.0

--- a/README.md
+++ b/README.md
@@ -578,7 +578,7 @@ The following parameters will be the same for each process in the set:
 ### Unreleased
 
 * Fixes issue where MsiPackage Integration tests fail to make an HTTPS
-  connection if Strong Crypto for .NET is not enabled.
+  connection if Strong Crypto for .NET is not enabled. Fixes
   [Issue #142](https://github.com/PowerShell/PSDscResources/issues/142)
 * Fix Custom DSC Resource Kit PSSA Rule Failures
 

--- a/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
@@ -14,10 +14,10 @@ if ($PSVersionTable.PSVersion -lt [Version] '5.1')
 }
 
 # Import CommonTestHelper
-$script:testsFolderFilePath = Split-Path -Path $PSScriptRoot -Parent
+$testsFolderFilePath = Split-Path -Path $PSScriptRoot -Parent
 $testHelperFolderFilePath = Join-Path -Path $testsFolderFilePath -ChildPath 'TestHelpers'
 $commonTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'CommonTestHelper.psm1'
-Import-Module -Name $script:commonTestHelperFilePath
+Import-Module -Name $commonTestHelperFilePath
 
 # Make sure strong crypto is enabled in .NET for HTTPS tests
 Enable-StrongCryptoForDotNetFour

--- a/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
@@ -22,7 +22,7 @@ Import-Module -Name $commonTestHelperFilePath
 try
 {
     # Make sure strong crypto is enabled in .NET for HTTPS tests
-    Enable-StrongCryptoForDotNetFour
+    $originalStrongCryptoSettings = Enable-StrongCryptoForDotNetFour
 
     Describe 'MsiPackage End to End Tests' {
         BeforeAll {

--- a/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
@@ -13,7 +13,8 @@ if ($PSVersionTable.PSVersion -lt [Version] '5.1')
     return
 }
 
-$script:testsFolderFilePath = Split-Path $PSScriptRoot -Parent
+# Import CommonTestHelper
+$script:testsFolderFilePath = Split-Path -Path $PSScriptRoot -Parent
 $testHelperFolderFilePath = Join-Path -Path $testsFolderFilePath -ChildPath 'TestHelpers'
 $commonTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'CommonTestHelper.psm1'
 Import-Module -Name $script:commonTestHelperFilePath

--- a/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
@@ -19,406 +19,100 @@ $testHelperFolderFilePath = Join-Path -Path $testsFolderFilePath -ChildPath 'Tes
 $commonTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'CommonTestHelper.psm1'
 Import-Module -Name $commonTestHelperFilePath
 
-# Make sure strong crypto is enabled in .NET for HTTPS tests
-Enable-StrongCryptoForDotNetFour
+try
+{
+    # Make sure strong crypto is enabled in .NET for HTTPS tests
+    Enable-StrongCryptoForDotNetFour
 
-Describe 'MsiPackage End to End Tests' {
-    BeforeAll {
-        # Import CommonTestHelper
-        $testsFolderFilePath = Split-Path $PSScriptRoot -Parent
-        $testHelperFolderFilePath = Join-Path -Path $testsFolderFilePath -ChildPath 'TestHelpers'
-        $commonTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'CommonTestHelper.psm1'
-        Import-Module -Name $commonTestHelperFilePath
+    Describe 'MsiPackage End to End Tests' {
+        BeforeAll {
+            # Import CommonTestHelper
+            $testsFolderFilePath = Split-Path $PSScriptRoot -Parent
+            $testHelperFolderFilePath = Join-Path -Path $testsFolderFilePath -ChildPath 'TestHelpers'
+            $commonTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'CommonTestHelper.psm1'
+            Import-Module -Name $commonTestHelperFilePath
 
-        $script:testEnvironment = Enter-DscResourceTestEnvironment `
-            -DscResourceModuleName 'PSDscResources' `
-            -DscResourceName 'MSFT_MsiPackage' `
-            -TestType 'Integration'
+            $script:testEnvironment = Enter-DscResourceTestEnvironment `
+                -DscResourceModuleName 'PSDscResources' `
+                -DscResourceName 'MSFT_MsiPackage' `
+                -TestType 'Integration'
 
-        # Import MsiPackage resource module for Test-TargetResource
-        $moduleRootFilePath = Split-Path -Path $testsFolderFilePath -Parent
-        $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
-        $msiPackageResourceFolderFilePath = Join-Path -Path $dscResourcesFolderFilePath -ChildPath 'MSFT_MsiPackage'
-        $msiPackageResourceModuleFilePath = Join-Path -Path $msiPackageResourceFolderFilePath -ChildPath 'MSFT_MsiPackage.psm1'
-        Import-Module -Name $msiPackageResourceModuleFilePath -Force
+            # Import MsiPackage resource module for Test-TargetResource
+            $moduleRootFilePath = Split-Path -Path $testsFolderFilePath -Parent
+            $dscResourcesFolderFilePath = Join-Path -Path $moduleRootFilePath -ChildPath 'DscResources'
+            $msiPackageResourceFolderFilePath = Join-Path -Path $dscResourcesFolderFilePath -ChildPath 'MSFT_MsiPackage'
+            $msiPackageResourceModuleFilePath = Join-Path -Path $msiPackageResourceFolderFilePath -ChildPath 'MSFT_MsiPackage.psm1'
+            Import-Module -Name $msiPackageResourceModuleFilePath -Force
 
-        # Import the MsiPackage test helper
-        $packageTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'MSFT_MsiPackageResource.TestHelper.psm1'
-        Import-Module -Name $packageTestHelperFilePath -Force
+            # Import the MsiPackage test helper
+            $packageTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'MSFT_MsiPackageResource.TestHelper.psm1'
+            Import-Module -Name $packageTestHelperFilePath -Force
 
-        # Set up the paths to the test configurations
-        $script:configurationFilePathNoOptionalParameters = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_MsiPackage_NoOptionalParameters'
-        $script:configurationFilePathLogPath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_MsiPackage_LogPath'
+            # Set up the paths to the test configurations
+            $script:configurationFilePathNoOptionalParameters = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_MsiPackage_NoOptionalParameters'
+            $script:configurationFilePathLogPath = Join-Path -Path $PSScriptRoot -ChildPath 'MSFT_MsiPackage_LogPath'
 
-        <#
-            This log file is used to log messages from the mock server which is important for debugging since
-            most of the work of the mock server is done within a separate process. 
-        #>
-        $script:logFile = Join-Path -Path $PSScriptRoot -ChildPath 'PackageTestLogFile.txt'
-        $script:environmentInIncorrectStateErrorMessage = 'The current environment is not in the expected state for this test - either something was setup incorrectly on your machine or a previous test failed - results after this may be invalid.'
+            <#
+                This log file is used to log messages from the mock server which is important for debugging since
+                most of the work of the mock server is done within a separate process. 
+            #>
+            $script:logFile = Join-Path -Path $PSScriptRoot -ChildPath 'PackageTestLogFile.txt'
+            $script:environmentInIncorrectStateErrorMessage = 'The current environment is not in the expected state for this test - either something was setup incorrectly on your machine or a previous test failed - results after this may be invalid.'
 
-        $script:msiName = 'DSCSetupProject.msi'
-        $script:msiLocation = Join-Path -Path $TestDrive -ChildPath $script:msiName
+            $script:msiName = 'DSCSetupProject.msi'
+            $script:msiLocation = Join-Path -Path $TestDrive -ChildPath $script:msiName
 
-        $script:packageId = '{deadbeef-80c6-41e6-a1b9-8bdb8a05027f}'
+            $script:packageId = '{deadbeef-80c6-41e6-a1b9-8bdb8a05027f}'
 
-        $null = New-TestMsi -DestinationPath $script:msiLocation
+            $null = New-TestMsi -DestinationPath $script:msiLocation
 
-        # Clear the log file
-        'Beginning integration tests' > $script:logFile
-    }
-
-    AfterAll {
-        # Remove the test MSI if it is still installed
-        if (Test-PackageInstalledById -ProductId $script:packageId)
-        {
-            $null = Start-Process -FilePath 'msiexec.exe' -ArgumentList @("/x$script:packageId", '/passive') -Wait
-            $null = Start-Sleep -Seconds 1
+            # Clear the log file
+            'Beginning integration tests' > $script:logFile
         }
 
-        if (Test-PackageInstalledById -ProductId $script:packageId)
-        {
-            throw 'Test package could not be uninstalled after running all tests. It may cause errors in subsequent test runs.'
-        }
-
-        Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
-    }
-
-    Context 'Uninstall package that is already Absent' {
-        $configurationName = 'RemoveAbsentMsiPackage'
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $script:msiLocation
-            Ensure = 'Absent'
-        }
-
-        It 'Should return True from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $true
-
-            if ($testTargetResourceInitialResult -ne $true)
+        AfterAll {
+            # Remove the test MSI if it is still installed
+            if (Test-PackageInstalledById -ProductId $script:packageId)
             {
-                <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
-                #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                $null = Start-Process -FilePath 'msiexec.exe' -ArgumentList @("/x$script:packageId", '/passive') -Wait
+                $null = Start-Sleep -Seconds 1
             }
-        }
 
-        It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        }
-
-        It 'Should compile and run configuration' {
-            { 
-                . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
-                & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
-        }
-
-        It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        }
-    }
-
-    Context 'Install package that is not installed yet' {
-        $configurationName = 'InstallMsiPackage'
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $script:msiLocation
-            Ensure = 'Present'
-        }
-
-        It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $false
-
-            if ($testTargetResourceInitialResult -ne $false)
+            if (Test-PackageInstalledById -ProductId $script:packageId)
             {
-                <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
-                #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                throw 'Test package could not be uninstalled after running all tests. It may cause errors in subsequent test runs.'
             }
+
+            Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
         }
 
-        It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        }
+        Context 'Uninstall package that is already Absent' {
+            $configurationName = 'RemoveAbsentMsiPackage'
 
-        It 'Should compile and run configuration' {
-            { 
-                . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
-                & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
-        }
-
-        It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
-    }
-
-    Context 'Install package that is already installed' {
-        $configurationName = 'InstallExistingMsiPackage'
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $script:msiLocation
-            Ensure = 'Present'
-        }
-
-        It 'Should return True from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $true
-
-            if ($testTargetResourceInitialResult -ne $true)
-            {
-                <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
-                #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $script:msiLocation
+                Ensure = 'Absent'
             }
-        }
 
-        It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
+            It 'Should return True from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $true
 
-        It 'Should compile and run configuration' {
-            { 
-                . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
-                & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
-        }
-
-        It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
-    }
-
-    Context 'Uninstall package that is installed' {
-        $configurationName = 'UninstallExistingMsiPackage'
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $script:msiLocation
-            Ensure = 'Absent'
-        }
-
-        It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $false
-
-            if ($testTargetResourceInitialResult -ne $false)
-            {
-                <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
-                #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                if ($testTargetResourceInitialResult -ne $true)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
             }
-        }
 
-        It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
-
-        It 'Should compile and run configuration' {
-            { 
-                . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
-                & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
-        }
-
-        It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        }
-    }
-
-    Context 'Install package that is not installed and write to specified log file' {
-        $configurationName = 'InstallWithLogFile'
-
-        $logPath = Join-Path -Path $TestDrive -ChildPath 'TestMsiLog.txt'
-
-        if (Test-Path -Path $logPath)
-        {
-            Remove-Item -Path $logPath -Force
-        }
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $script:msiLocation
-            Ensure = 'Present'
-            LogPath = $logPath
-        }
-
-        It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $false
-
-            if ($testTargetResourceInitialResult -ne $false)
-            {
-                <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
-                #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+            It 'Package should not exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
             }
-        }
-
-        It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        }
-
-        It 'Should compile and run configuration' {
-            { 
-                . $script:configurationFilePathLogPath -ConfigurationName $configurationName
-                & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
-        }
-
-        It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Should have created the log file' {
-            Test-Path -Path $logPath | Should Be $true
-        }
-
-        It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
-    }
-
-    Context 'Uninstall package that is installed and write to specified log file' {
-        $configurationName = 'InstallWithLogFile'
-
-        $logPath = Join-Path -Path $TestDrive -ChildPath 'TestMsiLog.txt'
-
-        if (Test-Path -Path $logPath)
-        {
-            Remove-Item -Path $logPath -Force
-        }
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $script:msiLocation
-            Ensure = 'Absent'
-            LogPath = $logPath
-        }
-
-        It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $false
-
-            if ($testTargetResourceInitialResult -ne $false)
-            {
-                <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
-                #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
-            }
-        }
-
-        It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
-
-        It 'Should compile and run configuration' {
-            { 
-                . $script:configurationFilePathLogPath -ConfigurationName $configurationName
-                & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-            } | Should Not Throw
-        }
-
-        It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Should have created the log file' {
-            Test-Path -Path $logPath | Should Be $true
-        }
-
-        It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        } 
-    }
-
-    Context 'Install package from HTTP Url' {
-        $configurationName = 'UninstallExistingMsiPackageFromHttp'
-
-        $baseUrl = 'http://localhost:1242/'
-        $msiUrl = "$baseUrl" + 'package.msi'
-
-        $fileServerStarted = $null
-        $job = $null
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $msiUrl
-            Ensure = 'Present'
-        }
-
-        It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $false
-
-            if ($testTargetResourceInitialResult -ne $false)
-            {
-                <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
-                #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
-            }
-        }
-
-        It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        }
-
-        try
-        {
-            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false
-            $fileServerStarted = $serverResult.FileServerStarted
-            $job = $serverResult.Job              
-
-            $fileServerStarted.WaitOne(30000)
 
             It 'Should compile and run configuration' {
                 { 
@@ -427,226 +121,541 @@ Describe 'MsiPackage End to End Tests' {
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
                 } | Should Not Throw
             }
-        }
-        finally
-        {
-            <#
-                This must be called after Start-Server to ensure the listening port is closed,
-                otherwise subsequent tests may fail until the machine is rebooted.
-            #>
-            Stop-Server -FileServerStarted $fileServerStarted -Job $job
-        }
 
-        It 'Should return True from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
+            It 'Should return True from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
 
-        It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
-    }
-
-    Context 'Uninstall Msi package from HTTP Url' {
-        $configurationName = 'InstallMsiPackageFromHttp'
-
-        $baseUrl = 'http://localhost:1242/'
-        $msiUrl = "$baseUrl" + 'package.msi'
-
-        $fileServerStarted = $null
-        $job = $null
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $msiUrl
-            Ensure = 'Absent'
-        }
-
-        It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $false
-
-            if ($testTargetResourceInitialResult -ne $false)
-            {
-                <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
-                #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+            It 'Package should not exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
             }
         }
 
-        It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+        Context 'Install package that is not installed yet' {
+            $configurationName = 'InstallMsiPackage'
+
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $script:msiLocation
+                Ensure = 'Present'
+            }
+
+            It 'Should return False from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $false
+
+                if ($testTargetResourceInitialResult -ne $false)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should not exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            }
+
+            It 'Should compile and run configuration' {
+                { 
+                    . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
+                    & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                } | Should Not Throw
+            }
+
+            It 'Should return True from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
+
+            It 'Package should exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
         }
+
+        Context 'Install package that is already installed' {
+            $configurationName = 'InstallExistingMsiPackage'
+
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $script:msiLocation
+                Ensure = 'Present'
+            }
+
+            It 'Should return True from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $true
+
+                if ($testTargetResourceInitialResult -ne $true)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
+
+            It 'Should compile and run configuration' {
+                { 
+                    . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
+                    & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                } | Should Not Throw
+            }
+
+            It 'Should return True from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
+
+            It 'Package should exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
+        }
+
+        Context 'Uninstall package that is installed' {
+            $configurationName = 'UninstallExistingMsiPackage'
+
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $script:msiLocation
+                Ensure = 'Absent'
+            }
+
+            It 'Should return False from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $false
+
+                if ($testTargetResourceInitialResult -ne $false)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
+
+            It 'Should compile and run configuration' {
+                { 
+                    . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
+                    & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                } | Should Not Throw
+            }
+
+            It 'Should return True from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
+
+            It 'Package should not exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            }
+        }
+
+        Context 'Install package that is not installed and write to specified log file' {
+            $configurationName = 'InstallWithLogFile'
+
+            $logPath = Join-Path -Path $TestDrive -ChildPath 'TestMsiLog.txt'
+
+            if (Test-Path -Path $logPath)
+            {
+                Remove-Item -Path $logPath -Force
+            }
+
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $script:msiLocation
+                Ensure = 'Present'
+                LogPath = $logPath
+            }
+
+            It 'Should return False from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $false
+
+                if ($testTargetResourceInitialResult -ne $false)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should not exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            }
+
+            It 'Should compile and run configuration' {
+                { 
+                    . $script:configurationFilePathLogPath -ConfigurationName $configurationName
+                    & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                } | Should Not Throw
+            }
+
+            It 'Should return True from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
+
+            It 'Should have created the log file' {
+                Test-Path -Path $logPath | Should Be $true
+            }
+
+            It 'Package should exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
+        }
+
+        Context 'Uninstall package that is installed and write to specified log file' {
+            $configurationName = 'InstallWithLogFile'
+
+            $logPath = Join-Path -Path $TestDrive -ChildPath 'TestMsiLog.txt'
+
+            if (Test-Path -Path $logPath)
+            {
+                Remove-Item -Path $logPath -Force
+            }
+
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $script:msiLocation
+                Ensure = 'Absent'
+                LogPath = $logPath
+            }
+
+            It 'Should return False from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $false
+
+                if ($testTargetResourceInitialResult -ne $false)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
+
+            It 'Should compile and run configuration' {
+                { 
+                    . $script:configurationFilePathLogPath -ConfigurationName $configurationName
+                    & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                } | Should Not Throw
+            }
+
+            It 'Should return True from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
+
+            It 'Should have created the log file' {
+                Test-Path -Path $logPath | Should Be $true
+            }
+
+            It 'Package should not exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            } 
+        }
+
+        Context 'Install package from HTTP Url' {
+            $configurationName = 'UninstallExistingMsiPackageFromHttp'
+
+            $baseUrl = 'http://localhost:1242/'
+            $msiUrl = "$baseUrl" + 'package.msi'
+
+            $fileServerStarted = $null
+            $job = $null
+
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $msiUrl
+                Ensure = 'Present'
+            }
+
+            It 'Should return False from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $false
+
+                if ($testTargetResourceInitialResult -ne $false)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should not exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            }
+
+            try
+            {
+                $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false
+                $fileServerStarted = $serverResult.FileServerStarted
+                $job = $serverResult.Job              
+
+                $fileServerStarted.WaitOne(30000)
+
+                It 'Should compile and run configuration' {
+                    { 
+                        . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
+                        & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                        Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                    } | Should Not Throw
+                }
+            }
+            finally
+            {
+                <#
+                    This must be called after Start-Server to ensure the listening port is closed,
+                    otherwise subsequent tests may fail until the machine is rebooted.
+                #>
+                Stop-Server -FileServerStarted $fileServerStarted -Job $job
+            }
+
+            It 'Should return True from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
+
+            It 'Package should exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
+        }
+
+        Context 'Uninstall Msi package from HTTP Url' {
+            $configurationName = 'InstallMsiPackageFromHttp'
+
+            $baseUrl = 'http://localhost:1242/'
+            $msiUrl = "$baseUrl" + 'package.msi'
+
+            $fileServerStarted = $null
+            $job = $null
+
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $msiUrl
+                Ensure = 'Absent'
+            }
+
+            It 'Should return False from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $false
+
+                if ($testTargetResourceInitialResult -ne $false)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
         
-        try
-        {
-            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false
-            $fileServerStarted = $serverResult.FileServerStarted
-            $job = $serverResult.Job
+            try
+            {
+                $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false
+                $fileServerStarted = $serverResult.FileServerStarted
+                $job = $serverResult.Job
 
-            $fileServerStarted.WaitOne(30000)
+                $fileServerStarted.WaitOne(30000)
 
-            It 'Should compile and run configuration' {
-                { 
-                    . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
-                    & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                It 'Should compile and run configuration' {
+                    { 
+                        . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
+                        & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                        Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                    } | Should Not Throw
+                }
             }
-        }
-        finally
-        {
-            <#
-                This must be called after Start-Server to ensure the listening port is closed,
-                otherwise subsequent tests may fail until the machine is rebooted.
-            #>
-            Stop-Server -FileServerStarted $fileServerStarted -Job $job
-        }
-
-        It 'Should return true from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        }
-    }
-
-    Context 'Install Msi package from HTTPS Url' {
-        $configurationName = 'InstallMsiPackageFromHttpS'
-
-        $baseUrl = 'https://localhost:1243/'
-        $msiUrl = "$baseUrl" + 'package.msi'
-
-        $fileServerStarted = $null
-        $job = $null
-
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $msiUrl
-            Ensure = 'Present'
-        }
-
-        It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $false
-
-            if ($testTargetResourceInitialResult -ne $false)
+            finally
             {
                 <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
+                    This must be called after Start-Server to ensure the listening port is closed,
+                    otherwise subsequent tests may fail until the machine is rebooted.
                 #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                Stop-Server -FileServerStarted $fileServerStarted -Job $job
+            }
+
+            It 'Should return true from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
+
+            It 'Package should not exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
             }
         }
 
-        It 'Package should not exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        }
+        Context 'Install Msi package from HTTPS Url' {
+            $configurationName = 'InstallMsiPackageFromHttpS'
+
+            $baseUrl = 'https://localhost:1243/'
+            $msiUrl = "$baseUrl" + 'package.msi'
+
+            $fileServerStarted = $null
+            $job = $null
+
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $msiUrl
+                Ensure = 'Present'
+            }
+
+            It 'Should return False from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $false
+
+                if ($testTargetResourceInitialResult -ne $false)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should not exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            }
         
-        try
-        {
-            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true
-            $fileServerStarted = $serverResult.FileServerStarted
-            $job = $serverResult.Job
+            try
+            {
+                $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true
+                $fileServerStarted = $serverResult.FileServerStarted
+                $job = $serverResult.Job
 
-            $fileServerStarted.WaitOne(30000)
+                $fileServerStarted.WaitOne(30000)
 
-            It 'Should compile and run configuration' {
-                { 
-                    . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
-                    & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+                It 'Should compile and run configuration' {
+                    { 
+                        . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
+                        & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                        Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                    } | Should Not Throw
+                }
+            }
+            finally
+            {
+                <#
+                    This must be called after Start-Server to ensure the listening port is closed,
+                    otherwise subsequent tests may fail until the machine is rebooted.
+                #>
+                Stop-Server -FileServerStarted $fileServerStarted -Job $job
+            }
+
+            It 'Should return true from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
+            }
+
+            It 'Package should exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
             }
         }
-        finally
-        {
-            <#
-                This must be called after Start-Server to ensure the listening port is closed,
-                otherwise subsequent tests may fail until the machine is rebooted.
-            #>
-            Stop-Server -FileServerStarted $fileServerStarted -Job $job
-        }
-
-        It 'Should return true from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Package should exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
-    }
     
-    Context 'Uninstall Msi package from HTTPS Url' {
-        $configurationName = 'UninstallMsiPackageFromHttps'
+        Context 'Uninstall Msi package from HTTPS Url' {
+            $configurationName = 'UninstallMsiPackageFromHttps'
 
-        $baseUrl = 'https://localhost:1243/'
-        $msiUrl = "$baseUrl" + 'package.msi'
+            $baseUrl = 'https://localhost:1243/'
+            $msiUrl = "$baseUrl" + 'package.msi'
 
-        $fileServerStarted = $null
-        $job = $null
+            $fileServerStarted = $null
+            $job = $null
 
-        $msiPackageParameters = @{
-            ProductId = $script:packageId
-            Path = $msiUrl
-            Ensure = 'Absent'
-        }
+            $msiPackageParameters = @{
+                ProductId = $script:packageId
+                Path = $msiUrl
+                Ensure = 'Absent'
+            }
 
-        It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
-            $testTargetResourceInitialResult | Should Be $false
+            It 'Should return False from Test-TargetResource with the same parameters before configuration' {
+                $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+                $testTargetResourceInitialResult | Should Be $false
 
-            if ($testTargetResourceInitialResult -ne $false)
+                if ($testTargetResourceInitialResult -ne $false)
+                {
+                    <#
+                        Not throwing an error here since the tests should still run correctly after this,
+                        we just want to notify the user that the tests aren't necessarily testing what
+                        they should be
+                    #>
+                    Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                }
+            }
+
+            It 'Package should exist on the machine before configuration is run' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
+            }
+
+            try
+            {
+                $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true
+                $fileServerStarted = $serverResult.FileServerStarted
+                $job = $serverResult.Job
+
+                $fileServerStarted.WaitOne(30000)
+
+                It 'Should compile and run configuration' {
+                    { 
+                        . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
+                        & $configurationName -OutputPath $TestDrive @msiPackageParameters
+                        Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
+                    } | Should Not Throw
+                }
+            }
+            finally
             {
                 <#
-                    Not throwing an error here since the tests should still run correctly after this,
-                    we just want to notify the user that the tests aren't necessarily testing what
-                    they should be
+                    This must be called after Start-Server to ensure the listening port is closed,
+                    otherwise subsequent tests may fail until the machine is rebooted.
                 #>
-                Write-Error -Message $script:environmentInIncorrectStateErrorMessage
+                Stop-Server -FileServerStarted $fileServerStarted -Job $job
             }
-        }
 
-        It 'Package should exist on the machine before configuration is run' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
-        }
-
-        try
-        {
-            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true
-            $fileServerStarted = $serverResult.FileServerStarted
-            $job = $serverResult.Job
-
-            $fileServerStarted.WaitOne(30000)
-
-            It 'Should compile and run configuration' {
-                { 
-                    . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
-                    & $configurationName -OutputPath $TestDrive @msiPackageParameters
-                    Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
-                } | Should Not Throw
+            It 'Should return true from Test-TargetResource with the same parameters after configuration' {
+                MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
             }
-        }
-        finally
-        {
-            <#
-                This must be called after Start-Server to ensure the listening port is closed,
-                otherwise subsequent tests may fail until the machine is rebooted.
-            #>
-            Stop-Server -FileServerStarted $fileServerStarted -Job $job
-        }
 
-        It 'Should return true from Test-TargetResource with the same parameters after configuration' {
-            MSFT_MsiPackage\Test-TargetResource @msiPackageParameters | Should Be $true
-        }
-
-        It 'Package should not exist on the machine' {
-            Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            It 'Package should not exist on the machine' {
+                Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
+            }
         }
     }
+}
+finally
+{
+    Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
+
+    Undo-ChangesToStrongCryptoForDotNetFour -OriginalSettings $originalStrongCryptoSettings
 }

--- a/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
@@ -655,7 +655,5 @@ try
 }
 finally
 {
-    Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
-
     Undo-ChangesToStrongCryptoForDotNetFour -OriginalSettings $originalStrongCryptoSettings
 }

--- a/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
@@ -13,6 +13,14 @@ if ($PSVersionTable.PSVersion -lt [Version] '5.1')
     return
 }
 
+$script:testsFolderFilePath = Split-Path $PSScriptRoot -Parent
+$testHelperFolderFilePath = Join-Path -Path $testsFolderFilePath -ChildPath 'TestHelpers'
+$commonTestHelperFilePath = Join-Path -Path $testHelperFolderFilePath -ChildPath 'CommonTestHelper.psm1'
+Import-Module -Name $script:commonTestHelperFilePath
+
+# Make sure strong crypto is enabled in .NET for HTTPS tests
+Enable-StrongCryptoForDotNetFour
+
 Describe 'MsiPackage End to End Tests' {
     BeforeAll {
         # Import CommonTestHelper

--- a/Tests/Integration/MSFT_MsiPackage.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.Integration.Tests.ps1
@@ -17,11 +17,11 @@ $script:testEnvironment = Enter-DscResourceTestEnvironment `
     -DscResourceName 'MSFT_MsiPackage' `
     -TestType 'Unit'
 
-# Make sure strong crypto is enabled in .NET for HTTPS tests
-Enable-StrongCryptoForDotNetFour
-
 try
 {
+    # Make sure strong crypto is enabled in .NET for HTTPS tests
+    $originalStrongCryptoSettings = Enable-StrongCryptoForDotNetFour
+
     InModuleScope 'MSFT_MsiPackage' {
         Describe 'MSFT_MsiPackage Integration Tests' {
             BeforeAll {
@@ -309,4 +309,6 @@ try
 finally
 {
     Exit-DscResourceTestEnvironment -TestEnvironment $script:testEnvironment
+
+    Undo-ChangesToStrongCryptoForDotNetFour -OriginalSettings $originalStrongCryptoSettings
 }

--- a/Tests/Integration/MSFT_MsiPackage.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.Integration.Tests.ps1
@@ -17,6 +17,9 @@ $script:testEnvironment = Enter-DscResourceTestEnvironment `
     -DscResourceName 'MSFT_MsiPackage' `
     -TestType 'Unit'
 
+# Make sure strong crypto is enabled in .NET for HTTPS tests
+Enable-StrongCryptoForDotNetFour
+
 try
 {
     InModuleScope 'MSFT_MsiPackage' {

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -836,6 +836,8 @@ function Enable-StrongCryptoForDotNetFour
             continue
         }
     }
+
+    return $originalValues
 }
 
 <#

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -801,7 +801,7 @@ function Enable-StrongCryptoForDotNetFour
     param()
 
     $regBases = @(
-        'HKLM:\SOFTWARE\Microsoft'
+        'HKLM:\SOFTWARE'
         'HKLM:\SOFTWARE\Wow6432Node'
     )
 

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -796,7 +796,6 @@ function Exit-DscResourceTestEnvironment
 #>
 function Enable-StrongCryptoForDotNetFour
 {
-    [OutputType([System.Boolean])]
     [CmdletBinding()]
     param()
 


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue where MsiPackage Integration tests fail if strong crypto is not enabled for .NET 4.

#### This Pull Request (PR) fixes the following issues
- Fixes #142 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/143)
<!-- Reviewable:end -->
