### PR TITLE
MSFT_MsiPackage: Fix HttpListener Issues with MsiPackage Integration Tests

### DIFF
--- a/DscResources/MSFT_MsiPackage/MSFT_MsiPackage.psm1
+++ b/DscResources/MSFT_MsiPackage/MSFT_MsiPackage.psm1
@@ -269,7 +269,7 @@ function Set-TargetResource
                     }
                     finally
                     {
-                        if ($null -ne $responseStream)
+                        if ((Test-Path -Path variable:responseStream) -and ($null -ne $responseStream))
                         {
                             Close-Stream -Stream $responseStream
                         }

--- a/README.md
+++ b/README.md
@@ -577,6 +577,16 @@ The following parameters will be the same for each process in the set:
 
 ### Unreleased
 
+* Fixes issue where MsiPackage Integration tests fail if the test HttpListener
+  fails to start. Moves the test HttpListener objects to dynamically assigned,
+  higher numbered ports to avoid conflicts with other services, and also checks
+  to ensure that the ports are available before using them. Adds checks to
+  ensure that no outstanding HTTP server jobs are running before attempting to
+  setup a new one. Also adds additional instrumentation to make it easier to
+  troubleshoot issues with the test HttpListener objects in the future.
+  Specifically fixes
+  [Issue #142](https://github.com/PowerShell/PSDscResources/issues/142)
+
 ### 2.11.0.0
 
 * Fix Custom DSC Resource Kit PSSA Rule Failures

--- a/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
@@ -55,6 +55,9 @@ Describe 'MsiPackage End to End Tests' {
 
         $null = New-TestMsi -DestinationPath $script:msiLocation
 
+        $script:testHttpPort = Get-UnusedTcpPort
+        $script:testHttpsPort = Get-UnusedTcpPort -ExcludePorts @($script:testHttpPort)
+
         # Clear the log file
         'Beginning integration tests' > $script:logFile
     }
@@ -372,7 +375,7 @@ Describe 'MsiPackage End to End Tests' {
     Context 'Install package from HTTP Url' {
         $configurationName = 'UninstallExistingMsiPackageFromHttp'
 
-        $baseUrl = 'http://localhost:1242/'
+        $baseUrl = "http://localhost:$script:testHttpPort/"
         $msiUrl = "$baseUrl" + 'package.msi'
 
         $fileServerStarted = $null
@@ -405,7 +408,10 @@ Describe 'MsiPackage End to End Tests' {
 
         try
         {
-            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false
+            # Make sure no existing HTTP(S) test servers are running
+            Stop-EveryTestServerInstance
+
+            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false -HttpPort $script:testHttpPort -HttpsPort $script:testHttpsPort
             $fileServerStarted = $serverResult.FileServerStarted
             $job = $serverResult.Job              
 
@@ -440,7 +446,7 @@ Describe 'MsiPackage End to End Tests' {
     Context 'Uninstall Msi package from HTTP Url' {
         $configurationName = 'InstallMsiPackageFromHttp'
 
-        $baseUrl = 'http://localhost:1242/'
+        $baseUrl = "http://localhost:$script:testHttpPort/"
         $msiUrl = "$baseUrl" + 'package.msi'
 
         $fileServerStarted = $null
@@ -473,7 +479,10 @@ Describe 'MsiPackage End to End Tests' {
         
         try
         {
-            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false
+            # Make sure no existing HTTP(S) test servers are running
+            Stop-EveryTestServerInstance
+
+            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false -HttpPort $script:testHttpPort -HttpsPort $script:testHttpsPort
             $fileServerStarted = $serverResult.FileServerStarted
             $job = $serverResult.Job
 
@@ -508,7 +517,7 @@ Describe 'MsiPackage End to End Tests' {
     Context 'Install Msi package from HTTPS Url' {
         $configurationName = 'InstallMsiPackageFromHttpS'
 
-        $baseUrl = 'https://localhost:1243/'
+        $baseUrl = "https://localhost:$script:testHttpsPort/"
         $msiUrl = "$baseUrl" + 'package.msi'
 
         $fileServerStarted = $null
@@ -541,7 +550,10 @@ Describe 'MsiPackage End to End Tests' {
         
         try
         {
-            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true
+            # Make sure no existing HTTP(S) test servers are running
+            Stop-EveryTestServerInstance
+
+            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true -HttpPort $script:testHttpPort -HttpsPort $script:testHttpsPort
             $fileServerStarted = $serverResult.FileServerStarted
             $job = $serverResult.Job
 
@@ -576,7 +588,7 @@ Describe 'MsiPackage End to End Tests' {
     Context 'Uninstall Msi package from HTTPS Url' {
         $configurationName = 'UninstallMsiPackageFromHttps'
 
-        $baseUrl = 'https://localhost:1243/'
+        $baseUrl = "https://localhost:$script:testHttpsPort/"
         $msiUrl = "$baseUrl" + 'package.msi'
 
         $fileServerStarted = $null
@@ -609,7 +621,10 @@ Describe 'MsiPackage End to End Tests' {
 
         try
         {
-            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true
+            # Make sure no existing HTTP(S) test servers are running
+            Stop-EveryTestServerInstance
+
+            $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true -HttpPort $script:testHttpPort -HttpsPort $script:testHttpsPort
             $fileServerStarted = $serverResult.FileServerStarted
             $job = $serverResult.Job
 

--- a/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.EndToEnd.Tests.ps1
@@ -43,7 +43,7 @@ Describe 'MsiPackage End to End Tests' {
 
         <#
             This log file is used to log messages from the mock server which is important for debugging since
-            most of the work of the mock server is done within a separate process. 
+            most of the work of the mock server is done within a separate process.
         #>
         $script:logFile = Join-Path -Path $PSScriptRoot -ChildPath 'PackageTestLogFile.txt'
         $script:environmentInIncorrectStateErrorMessage = 'The current environment is not in the expected state for this test - either something was setup incorrectly on your machine or a previous test failed - results after this may be invalid.'
@@ -88,7 +88,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return True from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $true
 
             if ($testTargetResourceInitialResult -ne $true)
@@ -107,7 +107,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should compile and run configuration' {
-            { 
+            {
                 . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -133,7 +133,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
@@ -152,7 +152,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should compile and run configuration' {
-            { 
+            {
                 . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -178,7 +178,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return True from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $true
 
             if ($testTargetResourceInitialResult -ne $true)
@@ -197,7 +197,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should compile and run configuration' {
-            { 
+            {
                 . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -223,7 +223,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
@@ -242,7 +242,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should compile and run configuration' {
-            { 
+            {
                 . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -276,7 +276,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
@@ -295,7 +295,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should compile and run configuration' {
-            { 
+            {
                 . $script:configurationFilePathLogPath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -333,7 +333,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
@@ -352,7 +352,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should compile and run configuration' {
-            { 
+            {
                 . $script:configurationFilePathLogPath -ConfigurationName $configurationName
                 & $configurationName -OutputPath $TestDrive @msiPackageParameters
                 Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -369,14 +369,15 @@ Describe 'MsiPackage End to End Tests' {
 
         It 'Package should not exist on the machine' {
             Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
-        } 
+        }
     }
 
     Context 'Install package from HTTP Url' {
         $configurationName = 'UninstallExistingMsiPackageFromHttp'
 
-        $baseUrl = "http://localhost:$script:testHttpPort/"
-        $msiUrl = "$baseUrl" + 'package.msi'
+        $uriBuilder = [System.UriBuilder]::new('http', 'localhost', $script:testHttpPort)
+        $uriBuilder.Path = 'package.msi'
+        $msiUrl = $uriBuilder.Uri.AbsoluteUri
 
         $fileServerStarted = $null
         $job = $null
@@ -388,7 +389,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
@@ -413,12 +414,12 @@ Describe 'MsiPackage End to End Tests' {
 
             $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $false -HttpPort $script:testHttpPort -HttpsPort $script:testHttpsPort
             $fileServerStarted = $serverResult.FileServerStarted
-            $job = $serverResult.Job              
+            $job = $serverResult.Job
 
             $fileServerStarted.WaitOne(30000)
 
             It 'Should compile and run configuration' {
-                { 
+                {
                     . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @msiPackageParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -446,8 +447,9 @@ Describe 'MsiPackage End to End Tests' {
     Context 'Uninstall Msi package from HTTP Url' {
         $configurationName = 'InstallMsiPackageFromHttp'
 
-        $baseUrl = "http://localhost:$script:testHttpPort/"
-        $msiUrl = "$baseUrl" + 'package.msi'
+        $uriBuilder = [System.UriBuilder]::new('http', 'localhost', $script:testHttpPort)
+        $uriBuilder.Path = 'package.msi'
+        $msiUrl = $uriBuilder.Uri.AbsoluteUri
 
         $fileServerStarted = $null
         $job = $null
@@ -459,7 +461,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
@@ -476,7 +478,7 @@ Describe 'MsiPackage End to End Tests' {
         It 'Package should exist on the machine before configuration is run' {
             Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
         }
-        
+
         try
         {
             # Make sure no existing HTTP(S) test servers are running
@@ -489,7 +491,7 @@ Describe 'MsiPackage End to End Tests' {
             $fileServerStarted.WaitOne(30000)
 
             It 'Should compile and run configuration' {
-                { 
+                {
                     . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @msiPackageParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -517,8 +519,9 @@ Describe 'MsiPackage End to End Tests' {
     Context 'Install Msi package from HTTPS Url' {
         $configurationName = 'InstallMsiPackageFromHttpS'
 
-        $baseUrl = "https://localhost:$script:testHttpsPort/"
-        $msiUrl = "$baseUrl" + 'package.msi'
+        $uriBuilder = [System.UriBuilder]::new('https', 'localhost', $script:testHttpsPort)
+        $uriBuilder.Path = 'package.msi'
+        $msiUrl = $uriBuilder.Uri.AbsoluteUri
 
         $fileServerStarted = $null
         $job = $null
@@ -530,7 +533,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
@@ -547,7 +550,7 @@ Describe 'MsiPackage End to End Tests' {
         It 'Package should not exist on the machine before configuration is run' {
             Test-PackageInstalledById -ProductId $script:packageId | Should Be $false
         }
-        
+
         try
         {
             # Make sure no existing HTTP(S) test servers are running
@@ -560,7 +563,7 @@ Describe 'MsiPackage End to End Tests' {
             $fileServerStarted.WaitOne(30000)
 
             It 'Should compile and run configuration' {
-                { 
+                {
                     . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @msiPackageParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force
@@ -584,12 +587,13 @@ Describe 'MsiPackage End to End Tests' {
             Test-PackageInstalledById -ProductId $script:packageId | Should Be $true
         }
     }
-    
+
     Context 'Uninstall Msi package from HTTPS Url' {
         $configurationName = 'UninstallMsiPackageFromHttps'
 
-        $baseUrl = "https://localhost:$script:testHttpsPort/"
-        $msiUrl = "$baseUrl" + 'package.msi'
+        $uriBuilder = [System.UriBuilder]::new('https', 'localhost', $script:testHttpsPort)
+        $uriBuilder.Path = 'package.msi'
+        $msiUrl = $uriBuilder.Uri.AbsoluteUri
 
         $fileServerStarted = $null
         $job = $null
@@ -601,7 +605,7 @@ Describe 'MsiPackage End to End Tests' {
         }
 
         It 'Should return False from Test-TargetResource with the same parameters before configuration' {
-            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters 
+            $testTargetResourceInitialResult = MSFT_MsiPackage\Test-TargetResource @msiPackageParameters
             $testTargetResourceInitialResult | Should Be $false
 
             if ($testTargetResourceInitialResult -ne $false)
@@ -631,7 +635,7 @@ Describe 'MsiPackage End to End Tests' {
             $fileServerStarted.WaitOne(30000)
 
             It 'Should compile and run configuration' {
-                { 
+                {
                     . $script:configurationFilePathNoOptionalParameters -ConfigurationName $configurationName
                     & $configurationName -OutputPath $TestDrive @msiPackageParameters
                     Start-DscConfiguration -Path $TestDrive -ErrorAction 'Stop' -Wait -Force

--- a/Tests/Integration/MSFT_MsiPackage.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_MsiPackage.Integration.Tests.ps1
@@ -37,7 +37,7 @@ try
 
                 <#
                     This log file is used to log messages from the mock server which is important for debugging since
-                    most of the work of the mock server is done within a separate process. 
+                    most of the work of the mock server is done within a separate process.
                 #>
                 $script:logFile = Join-Path -Path $PSScriptRoot -ChildPath 'PackageTestLogFile.txt'
 
@@ -174,8 +174,11 @@ try
                 }
 
                 It 'Should correctly install and remove a package from a HTTP URL' {
-                    $baseUrl = "http://localhost:$script:testHttpPort/"
-                    $msiUrl = "$baseUrl" + 'package.msi'
+                    $uriBuilder = [System.UriBuilder]::new('http', 'localhost', $script:testHttpPort)
+                    $baseUrl = $uriBuilder.Uri.AbsoluteUri
+
+                    $uriBuilder.Path = 'package.msi'
+                    $msiUrl = $uriBuilder.Uri.AbsoluteUri
 
                     $fileServerStarted = $null
                     $job = $null
@@ -219,9 +222,11 @@ try
                 }
 
                 It 'Should correctly install and remove a package from a HTTPS URL' -Skip:$script:skipHttpsTest {
+                    $uriBuilder = [System.UriBuilder]::new('https', 'localhost', $script:testHttpsPort)
+                    $baseUrl = $uriBuilder.Uri.AbsoluteUri
 
-                    $baseUrl = "https://localhost:$script:testHttpsPort/"
-                    $msiUrl = "$baseUrl" + 'package.msi'
+                    $uriBuilder.Path = 'package.msi'
+                    $msiUrl = $uriBuilder.Uri.AbsoluteUri
 
                     $fileServerStarted = $null
                     $job = $null
@@ -235,7 +240,7 @@ try
 
                         $serverResult = Start-Server -FilePath $script:msiLocation -LogPath $script:logFile -Https $true -HttpPort $script:testHttpPort -HttpsPort $script:testHttpsPort
                         $fileServerStarted = $serverResult.FileServerStarted
-                        $job = $serverResult.Job             
+                        $job = $serverResult.Job
 
                         # Wait for the file server to be ready to receive requests
                         $fileServerStarted.WaitOne(30000)

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -832,7 +832,7 @@ function Get-UnusedTcpPort
 
     if ($HighestPortNumber -lt $LowestPortNumber)
     {
-        throw "HighestPortNumber must be greater than or equal to LowestPortNumber"
+        throw 'HighestPortNumber must be greater than or equal to LowestPortNumber'
     }
 
     [System.UInt16] $unusedPort = 0

--- a/Tests/TestHelpers/CommonTestHelper.psm1
+++ b/Tests/TestHelpers/CommonTestHelper.psm1
@@ -157,7 +157,7 @@ function Invoke-ExpectedMocksAreCalledTest
         Each item in the array is a hashtable that contains the name of the command
         being mocked, the number of times it is called (can be 0) and, optionally,
         an extra custom string to make the test name more descriptive. The custom
-        string will only work if the command has a corresponding variable in the 
+        string will only work if the command has a corresponding variable in the
         string data name.
 
     .PARAMETER ShouldThrow
@@ -227,7 +227,7 @@ function Invoke-GenericUnitTest {
         Each item in the array is a hashtable that contains the name of the command
         being mocked, the number of times it is called (can be 0) and, optionally,
         an extra custom string to make the test name more descriptive. The custom
-        string will only work if the command has a corresponding variable in the 
+        string will only work if the command has a corresponding variable in the
         string data name.
 
     .PARAMETER ExpectedReturnValue
@@ -288,7 +288,7 @@ function Invoke-GetTargetResourceUnitTest
         Each item in the array is a hashtable that contains the name of the command
         being mocked, the number of times it is called (can be 0) and, optionally,
         an extra custom string to make the test name more descriptive. The custom
-        string will only work if the command has a corresponding variable in the 
+        string will only work if the command has a corresponding variable in the
         string data name.
 
     .PARAMETER ShouldThrow
@@ -354,7 +354,7 @@ function Invoke-SetTargetResourceUnitTest {
         Each item in the array is a hashtable that contains the name of the command
         being mocked, the number of times it is called (can be 0) and, optionally,
         an extra custom string to make the test name more descriptive. The custom
-        string will only work if the command has a corresponding variable in the 
+        string will only work if the command has a corresponding variable in the
         string data name.
 
     .PARAMETER ExpectedReturnValue
@@ -573,7 +573,7 @@ function Test-IsFileLocked
     .PARAMETER ExpectedOutput
         The output expected to be in the output from running WhatIf with the Set-TargetResource cmdlet.
         If this parameter is empty or null, this cmdlet will check that there was no output from
-        Set-TargetResource with WhatIf specified.    
+        Set-TargetResource with WhatIf specified.
 #>
 function Test-SetTargetResourceWithWhatIf
 {
@@ -584,7 +584,7 @@ function Test-SetTargetResourceWithWhatIf
         [Parameter(Mandatory = $true)]
         [Hashtable]
         $Parameters,
-     
+
         [String[]]
         $ExpectedOutput
     )
@@ -837,23 +837,27 @@ function Get-UnusedTcpPort
 
     [System.UInt16] $unusedPort = 0
 
-    $usedPorts = (Get-NetTCPConnection).LocalPort | Where-Object -FilterScript {$_ -ge $LowestPortNumber -and $_ -le $HighestPortNumber}
-
-    if (!(Test-Path -Path variable:usedPorts) -or ($usedPorts -eq $null))
-    {
-        $usedPorts = @()
+    [System.Collections.ArrayList] $usedAndExcludedPorts = (Get-NetTCPConnection).LocalPort | Where-Object -FilterScript {
+        $_ -ge $LowestPortNumber -and $_ -le $HighestPortNumber
     }
 
-    if (!(Test-Path -Path variable:ExcludePorts) -or ($ExcludePorts -eq $null))
+    if (!(Test-Path -Path variable:usedAndExcludedPorts) -or ($null -eq $usedAndExcludedPorts))
+    {
+        [System.Collections.ArrayList] $usedAndExcludedPorts = @()
+    }
+
+    if (!(Test-Path -Path variable:ExcludePorts) -or ($null -eq $ExcludePorts))
     {
         $ExcludePorts = @()
     }
 
-    for ($i = $LowestPortNumber; $i -le $HighestPortNumber; $i++)
+    $null = $usedAndExcludedPorts.Add($ExcludePorts)
+
+    foreach ($port in $LowestPortNumber..$HighestPortNumber)
     {
-        if (!($usedPorts.Contains($i)) -and !($ExcludePorts.Contains($i)))
+        if (!($usedAndExcludedPorts.Contains($port)))
         {
-            $unusedPort = $i
+            $unusedPort = $port
             break
         }
     }

--- a/Tests/TestHelpers/MSFT_MsiPackageResource.TestHelper.psm1
+++ b/Tests/TestHelpers/MSFT_MsiPackageResource.TestHelper.psm1
@@ -100,7 +100,7 @@ function Start-Server
                                     'HttpIntegrationTest.FileServerStarted')
     $null = $fileServerStarted.Reset()
 
-    <# 
+    <#
         The server is run on a separate process so that it can receive requests
         while the tests continue to run. It takes in the same parameterss that are passed
         in to this function. All helper functions that the server uses have to be
@@ -130,7 +130,7 @@ function Start-Server
             (
                 [Parameter(Mandatory = $true)]
                 [System.Net.HttpListener]
-                $HttpListener, 
+                $HttpListener,
 
                 [Parameter(Mandatory = $true)]
                 [System.Boolean]
@@ -203,7 +203,7 @@ function Start-Server
             # Create certificate
             $certificate = New-SelfSignedCertificate -CertStoreLocation 'Cert:\LocalMachine\My' -DnsName localhost
             Write-Log -LogFile $LogPath -Message 'Created certificate'
-            
+
             $hash = $certificate.Thumbprint
             $certPassword = ConvertTo-SecureString -String 'password12345' -AsPlainText -Force
             $tempPath = 'C:\certForTesting'
@@ -211,9 +211,9 @@ function Start-Server
             $null = Export-PfxCertificate -Cert $certificate -FilePath $tempPath -Password $certPassword
             $null = Import-PfxCertificate -CertStoreLocation 'Cert:\LocalMachine\Root' -FilePath 'C:\certForTesting' -Password $certPassword
             Remove-Item -Path $tempPath
-            
+
             Write-Log -LogFile $LogPath -Message 'Finished importing certificate into root. About to bind it to port.'
-             
+
             # Use net shell command to directly bind certificate to designated testing port
             $null = netsh http add sslcert ipport=0.0.0.0:$HttpsPort certhash=$hash appid='{833f13c2-319a-4799-9d1a-5b267a0c3593}' clientcertnegotiation=enable
         }
@@ -239,32 +239,32 @@ function Start-Server
             # Add the CallbackEventBridge type if it's not already defined
             if (-not ('CallbackEventBridge' -as [Type]))
             {
-                Add-Type @' 
-                    using System; 
- 
-                    public sealed class CallbackEventBridge { 
-                        public event AsyncCallback CallbackComplete = delegate { }; 
- 
-                        private CallbackEventBridge() {} 
- 
+                Add-Type @'
+                    using System;
+
+                    public sealed class CallbackEventBridge {
+                        public event AsyncCallback CallbackComplete = delegate { };
+
+                        private CallbackEventBridge() {}
+
                         private void CallbackInternal(IAsyncResult result)
-                        { 
-                            CallbackComplete(result); 
-                        } 
- 
+                        {
+                            CallbackComplete(result);
+                        }
+
                         public AsyncCallback Callback
-                        { 
-                            get { return new AsyncCallback(CallbackInternal); } 
-                        } 
- 
+                        {
+                            get { return new AsyncCallback(CallbackInternal); }
+                        }
+
                         public static CallbackEventBridge Create()
-                        { 
-                            return new CallbackEventBridge(); 
-                        } 
-                    } 
+                        {
+                            return new CallbackEventBridge();
+                        }
+                    }
 '@
             }
-    
+
             $bridge = [CallbackEventBridge]::Create()
             Register-ObjectEvent -InputObject $bridge -EventName 'CallbackComplete' -Action $Callback -MessageData $args > $null
             $bridge.Callback
@@ -284,7 +284,7 @@ function Start-Server
 
             .PARAMETER ScriptBlock
                 The code to execute.
-                
+
         #>
         function Invoke-ConsoleCommand
         {
@@ -312,7 +312,7 @@ function Start-Server
                 $message = ('Failed action ''{0}'' on target ''{1}'' (exit code {2}): {3}' -f $Action,$Target,$LASTEXITCODE,$output)
                 Write-Error -Message $message
                 Write-Log -LogFile $LogPath -Message "Error from Invoke-ConsoleCommand: $message"
-            } 
+            }
             else
             {
                 $nonNullOutput = $output | Where-Object { $_ -ne $null }
@@ -344,7 +344,7 @@ function Start-Server
                 [String]
                 $Message
             )
-            
+
             $Message >> $LogFile
         }
 
@@ -409,7 +409,7 @@ function Start-Server
 
                 .PARAMETER Result
                     th IAsyncResult containing the listener object and path to the MSI file.
-                    
+
             #>
             $requestListener =
             {
@@ -495,10 +495,10 @@ function Start-Server
             $_.Exception | ConvertTo-Xml -As String >> $LogPath
 
             'Running Process Info' >> $LogPath
-            Get-Process | fl | Out-String >> $LogPath
+            Get-Process | Format-List | Out-String >> $LogPath
 
             'Open TCP Connections Info' >> $LogPath
-            Get-NetTCPConnection | fl | Out-String >> $LogPath
+            Get-NetTCPConnection | Format-List | Out-String >> $LogPath
 
             throw $_
         }
@@ -508,7 +508,7 @@ function Start-Server
             {
                 $fileServerStarted.Dispose()
             }
-            
+
             Write-Log -LogFile $LogPath -Message 'Stopping the Server'
             Stop-Listener -HttpListener $HttpListener -Https $Https -HttpsPort $HttpsPort
         }
@@ -537,10 +537,10 @@ function Start-Server
     }
 
     <#
-        Return the event object so that client knows when it can start sending requests and 
+        Return the event object so that client knows when it can start sending requests and
         the job object so that the client can stop the job once it is done sending requests.
     #>
-    return @{ 
+    return @{
         FileServerStarted = $fileServerStarted
         Job = $job
     }
@@ -570,7 +570,7 @@ function Stop-Server
         $FileServerStarted,
 
         [System.Management.Automation.Job]
-        $Job  
+        $Job
     )
 
     if ($null -ne $FileServerStarted)
@@ -593,9 +593,7 @@ function Stop-Server
 function Stop-EveryTestServerInstance
 {
     [CmdletBinding()]
-    param
-    (
-    )
+    param ()
 
     Get-Job -Name "$($testJobPrefix)*" | Stop-Job
     Get-Job -Name "$($testJobPrefix)*" | Remove-Job
@@ -611,7 +609,7 @@ function Stop-EveryTestServerInstance
 function New-TestMsi
 {
     [CmdletBinding()]
-    param    
+    param
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]

--- a/Tests/TestHelpers/MSFT_MsiPackageResource.TestHelper.psm1
+++ b/Tests/TestHelpers/MSFT_MsiPackageResource.TestHelper.psm1
@@ -60,6 +60,12 @@ function Test-PackageInstalledById
         and listen on port 'https://localhost:HttpsPort'. Otherwise the file server will use Http and
         listen on port 'http://localhost:HttpPort'
         Default value is False (Http).
+
+    .PARAMETER HttpPort
+        Specifies the TCP port to register an Http based HttpListener on.
+
+    .PARAMETER HttspPort
+        Specifies the TCP port to register an Https based HttpListener on.
 #>
 function Start-Server
 {
@@ -113,6 +119,9 @@ function Start-Server
 
             .PARAMETER Https
                 Indicates whether https was used and if so, removes the SSL binding.
+
+            .PARAMETER HttspPort
+                Specifies the TCP port to de-register an Https based HttpListener from.
         #>
         function Stop-Listener
         {
@@ -176,6 +185,9 @@ function Start-Server
         <#
             .SYNOPSIS
                 Creates and registers an SSL certificate for Https connections.
+
+            .PARAMETER HttspPort
+                Specifies the TCP port to register an Https based HttpListener on.
         #>
         function Register-Ssl
         {

--- a/Tests/Unit/MSFT_MsiPackage.Tests.ps1
+++ b/Tests/Unit/MSFT_MsiPackage.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'MsiPackage Unit Tests' {
                                              -ExpectedReturnValue $expectedReturnValue
             }
         }
-           
+
         Describe 'Set-TargetResource' {
             $setTargetResourceParameters = @{
                 ProductId = 'TestProductId'
@@ -138,7 +138,7 @@ Describe 'MsiPackage Unit Tests' {
                 ServerCertificateValidationCallback = 'TestValidationCallback'
                 RunAsCredential = $script:testCredential
             }
-            
+
             Mock -CommandName 'Convert-PathToUri' -MockWith { return $script:testUriNonUnc }
             Mock -CommandName 'Convert-ProductIdToIdentifyingNumber' -MockWith { return $script:testIdentifyingNumber }
             Mock -CommandName 'Assert-PathExtensionValid' -MockWith {}
@@ -158,7 +158,7 @@ Describe 'MsiPackage Unit Tests' {
             Mock -CommandName 'Invoke-CimMethod' -MockWith {}
             Mock -CommandName 'Get-ItemProperty' -MockWith { return $null }
             Mock -CommandName 'Get-ProductEntry' -MockWith { return $script:mockProductEntry }
-            
+
             Context 'Uri scheme is non-UNC file and installation succeeds' {
                 $mocksCalled = @(
                     @{ Command = 'Convert-PathToUri'; Times = 1 }
@@ -349,7 +349,7 @@ Describe 'MsiPackage Unit Tests' {
                                              -ErrorMessage ($script:localizedData.PostValidationError -f $setTargetResourceParameters.Path) `
                                              -ErrorTestName $script:errorMessageTitles.PostValidationError
             }
-            
+
             Mock -CommandName 'Get-MsiProductCode' -MockWith { return $script:testWrongProductId }
 
             Context 'Product code from downloaded MSI package does not match specified ID' {
@@ -491,19 +491,19 @@ Describe 'MsiPackage Unit Tests' {
 
                     Convert-PathToUri -Path $filePath | Should Be $expectedReturnValue
                 }
-                
-                It 'Should return the expected URI when scheme is http' {
-                    $filePath = 'http://localhost/testMsi.msi'
-                    $expectedReturnValue = [Uri] $filePath
 
-                    Convert-PathToUri -Path $filePath | Should Be $expectedReturnValue
+                It 'Should return the expected URI when scheme is http' {
+                    $uriBuilder = [System.UriBuilder]::new('http', 'localhost')
+                    $uriBuilder.Path = 'testMsi.msi'
+
+                    Convert-PathToUri -Path $filePath | Should Be $uriBuilder.Uri
                 }
 
                 It 'Should return the expected URI when scheme is https' {
-                    $filePath = 'https://localhost/testMsi.msi'
-                    $expectedReturnValue = [Uri] $filePath
+                    $uriBuilder = [System.UriBuilder]::new('https', 'localhost')
+                    $uriBuilder.Path = 'testMsi.msi'
 
-                    Convert-PathToUri -Path $filePath | Should Be $expectedReturnValue
+                    Convert-PathToUri -Path $filePath | Should Be $uriBuilder.Uri
                 }
             }
 
@@ -686,7 +686,7 @@ Describe 'MsiPackage Unit Tests' {
                                        -ErrorTestName $script:errorMessageTitles.CouldNotOpenLog
             }
         }
-        
+
         Describe 'Get-WebRequestResponse' {
             Mock -CommandName 'Get-WebRequest' -MockWith { return $script:mockWebRequest }
             Mock -CommandName 'Get-ScriptBlock' -MockWith { return { Write-Verbose 'Hello World' } }
@@ -702,7 +702,7 @@ Describe 'MsiPackage Unit Tests' {
                 It 'Should return the expected response stream' {
                     Get-WebRequestResponse -Uri $script:testUriHttp | Should Be $script:mockStream
                 }
-                
+
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
             }
 
@@ -716,7 +716,7 @@ Describe 'MsiPackage Unit Tests' {
                 It 'Should return the expected response stream' {
                     Get-WebRequestResponse -Uri $script:testUriHttps | Should Be $script:mockStream
                 }
-                
+
                 Invoke-ExpectedMocksAreCalledTest -MocksCalled $mocksCalled
             }
 
@@ -859,7 +859,7 @@ Describe 'MsiPackage Unit Tests' {
         Describe 'Assert-FileSignatureValid' {
             $mockThumbprint = 'mockThumbprint'
             $mockSubject = 'mockSubject'
-            $mockSignature = @{ 
+            $mockSignature = @{
                 Status = [System.Management.Automation.SignatureStatus]::Valid
                 SignerCertificate = @{ Thumbprint = $mockThumbprint; Subject = $mockSubject }
             }

--- a/Tests/Unit/MSFT_MsiPackage.Tests.ps1
+++ b/Tests/Unit/MSFT_MsiPackage.Tests.ps1
@@ -495,6 +495,7 @@ Describe 'MsiPackage Unit Tests' {
                 It 'Should return the expected URI when scheme is http' {
                     $uriBuilder = [System.UriBuilder]::new('http', 'localhost')
                     $uriBuilder.Path = 'testMsi.msi'
+                    $filePath = $uriBuilder.Uri.AbsoluteUri
 
                     Convert-PathToUri -Path $filePath | Should Be $uriBuilder.Uri
                 }
@@ -502,6 +503,7 @@ Describe 'MsiPackage Unit Tests' {
                 It 'Should return the expected URI when scheme is https' {
                     $uriBuilder = [System.UriBuilder]::new('https', 'localhost')
                     $uriBuilder.Path = 'testMsi.msi'
+                    $filePath = $uriBuilder.Uri.AbsoluteUri
 
                     Convert-PathToUri -Path $filePath | Should Be $uriBuilder.Uri
                 }

--- a/Tests/Unit/MSFT_MsiPackage.Tests.ps1
+++ b/Tests/Unit/MSFT_MsiPackage.Tests.ps1
@@ -219,13 +219,13 @@ Describe 'MsiPackage Unit Tests' {
                     @{ Command = 'Assert-PathExtensionValid'; Times = 1 }
                     @{ Command = 'New-LogFile'; Times = 1 }
                     @{ Command = 'New-PSDrive'; Times = 0 }
-                    @{ Command = 'Test-Path'; Times = 2; Custom = 'to the package cache' }
+                    @{ Command = 'Test-Path'; Times = 3; Custom = 'to the package cache' }
                     @{ Command = 'New-Item'; Times = 0; Custom = 'directory for the package cache' }
                     @{ Command = 'New-Object'; Times = 1; Custom = 'file stream to copy the response to' }
                     @{ Command = 'Get-WebRequestResponse'; Times = 1 }
                     @{ Command = 'Copy-ResponseStreamToFileStream'; Times = 1 }
                     @{ Command = 'Close-Stream'; Times = 2 }
-                    @{ Command = 'Test-Path'; Times = 2; Custom = 'to the MSI file' }
+                    @{ Command = 'Test-Path'; Times = 3; Custom = 'to the MSI file' }
                     @{ Command = 'Assert-FileValid'; Times = 1 }
                     @{ Command = 'Get-MsiProductCode'; Times = 1 }
                     @{ Command = 'Start-MsiProcess'; Times = 1 }
@@ -250,13 +250,13 @@ Describe 'MsiPackage Unit Tests' {
                     @{ Command = 'Assert-PathExtensionValid'; Times = 1 }
                     @{ Command = 'New-LogFile'; Times = 1 }
                     @{ Command = 'New-PSDrive'; Times = 0 }
-                    @{ Command = 'Test-Path'; Times = 2; Custom = 'to the package cache' }
+                    @{ Command = 'Test-Path'; Times = 3; Custom = 'to the package cache' }
                     @{ Command = 'New-Item'; Times = 0; Custom = 'directory for the package cache' }
                     @{ Command = 'New-Object'; Times = 1; Custom = 'file stream to copy the response to' }
                     @{ Command = 'Get-WebRequestResponse'; Times = 1 }
                     @{ Command = 'Copy-ResponseStreamToFileStream'; Times = 1 }
                     @{ Command = 'Close-Stream'; Times = 2 }
-                    @{ Command = 'Test-Path'; Times = 2; Custom = 'to the MSI file' }
+                    @{ Command = 'Test-Path'; Times = 3; Custom = 'to the MSI file' }
                     @{ Command = 'Assert-FileValid'; Times = 1 }
                     @{ Command = 'Get-MsiProductCode'; Times = 1 }
                     @{ Command = 'Start-MsiProcess'; Times = 1 }
@@ -493,14 +493,14 @@ Describe 'MsiPackage Unit Tests' {
                 }
                 
                 It 'Should return the expected URI when scheme is http' {
-                    $filePath = 'http://localhost:1242/testMsi.msi'
+                    $filePath = 'http://localhost/testMsi.msi'
                     $expectedReturnValue = [Uri] $filePath
 
                     Convert-PathToUri -Path $filePath | Should Be $expectedReturnValue
                 }
 
                 It 'Should return the expected URI when scheme is https' {
-                    $filePath = 'https://localhost:1243/testMsi.msi'
+                    $filePath = 'https://localhost/testMsi.msi'
                     $expectedReturnValue = [Uri] $filePath
 
                     Convert-PathToUri -Path $filePath | Should Be $expectedReturnValue
@@ -509,7 +509,7 @@ Describe 'MsiPackage Unit Tests' {
 
             Context 'Invalid path passed in' {
                 It 'Should throw an error when uri scheme is invalid' {
-                    $filePath = 'ht://localhost:1243/testMsi.msi'
+                    $filePath = 'ht://localhost/testMsi.msi'
                     $expectedErrorMessage = ($script:localizedData.InvalidPath -f $filePath)
 
                     { Convert-PathToUri -Path $filePath } | Should Throw $expectedErrorMessage


### PR DESCRIPTION
#### Pull Request (PR) description
* Fixes issue where MsiPackage Integration tests fail if the test HttpListener
  fails to start. Moves the test HttpListener objects to dynamically assigned,
  higher numbered ports to avoid conflicts with other services, and also checks
  to ensure that the ports are available before using them. Adds checks to
  ensure that no outstanding HTTP server jobs are running before attempting to
  setup a new one. Also adds additional instrumentation to make it easier to
  troubleshoot issues with the test HttpListener objects in the future.

#### This Pull Request (PR) fixes the following issues
- Fixes #142 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the README.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/psdscresources/157)
<!-- Reviewable:end -->
