### PR TITLE
WindowsOptionalFeature: Ensure empty array output is not enumerated prematurely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+* Proposed fix for WindowsOptionalFeature DSC Resource GET method when the OptionalFeature has no Custom Properties.
+  [Issue #191](https://github.com/PowerShell/PSDscResources/issues/191)
+
 ## 2.12.0.0
 
 * Ports style fixes that were recently made in xPSDesiredStateConfiguration

--- a/DscResources/MSFT_WindowsOptionalFeature/MSFT_WindowsOptionalFeature.psm1
+++ b/DscResources/MSFT_WindowsOptionalFeature/MSFT_WindowsOptionalFeature.psm1
@@ -330,7 +330,7 @@ function Convert-CustomPropertyArrayToStringArray
         }
     }
 
-    return $propertiesAsStrings
+    Write-Output $propertiesAsStrings -NoEnumerate
 }
 
 <#

--- a/Tests/Unit/MSFT_WindowsOptionalFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_WindowsOptionalFeature.Tests.ps1
@@ -317,6 +317,10 @@ try
                         $propertiesAsStrings.Contains("Name = Object $objectNumber, Value = Value $objectNumber, Path = Path $objectNumber") | Should -BeTrue
                     }
                 }
+
+                It 'Should return an empty array and not a null object when input is empty' {
+                    $propertiesAsStrings = (Convert-CustomPropertyArrayToStringArray -CustomProperties @()) -is [String[]] | Should -BeTrue
+                }
             }
         }
     }

--- a/Tests/Unit/MSFT_WindowsOptionalFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_WindowsOptionalFeature.Tests.ps1
@@ -318,7 +318,7 @@ try
                     }
                 }
 
-                It 'Should return an empty array and not a null object when input is empty' {
+                It 'Should return an empty array and not a null object when input is an empty array' {
                     (Convert-CustomPropertyArrayToStringArray -CustomProperties @()) -is [String[]] | Should -BeTrue
                 }
             }

--- a/Tests/Unit/MSFT_WindowsOptionalFeature.Tests.ps1
+++ b/Tests/Unit/MSFT_WindowsOptionalFeature.Tests.ps1
@@ -319,7 +319,7 @@ try
                 }
 
                 It 'Should return an empty array and not a null object when input is empty' {
-                    $propertiesAsStrings = (Convert-CustomPropertyArrayToStringArray -CustomProperties @()) -is [String[]] | Should -BeTrue
+                    (Convert-CustomPropertyArrayToStringArray -CustomProperties @()) -is [String[]] | Should -BeTrue
                 }
             }
         }


### PR DESCRIPTION
#### Pull Request (PR) description
Ensure empty array output is not enumerated prematurely.

#### This Pull Request (PR) fixes the following issues
- Fixes #191

#### Task list
- [x] Added an entry under the Unreleased section in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
